### PR TITLE
fix: typescript extension bug fix

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/protocol/protocol.d.ts
+++ b/extensions/typescript-language-features/src/tsServer/protocol/protocol.d.ts
@@ -23,7 +23,7 @@ declare module '../../../../node_modules/typescript/lib/typescript' {
 			canIncreaseVerbosityLevel?: boolean;
 		}
 		interface UserPreferences {
-			maximumHoverLength?: boolean;
+			readonly maximumHoverLength?: number;
 		}
 	}
 }


### PR DESCRIPTION
Change maximumHoverLength type from boolean to number in UserPreferences interface

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
