### PR TITLE
chore: Update version numbers and enhance logging in update services

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siid",
-  "version": "1.102.0",
+  "version": "1.105.1",
   "distro": "90dfd14573cba753b9d5d02aa01f48dc1e8c4db9",
   "author": {
     "name": "ConscendoTechInc"

--- a/product.json
+++ b/product.json
@@ -21,8 +21,8 @@
 	"linuxIconName": "siid",
 	"licenseFileName": "LICENSE.rtf",
 	"licenseName": "MIT License",
-	"engineVersion": "1.104.1",
-	"version": "",
+	"engineVersion": "1.105.1",
+	"version": "2025.0.0",
 	"serverGreeting": [],
 	"serverLicense": [
 		"*",

--- a/src/vs/platform/update/electron-main/updateService.darwin.ts
+++ b/src/vs/platform/update/electron-main/updateService.darwin.ts
@@ -116,7 +116,8 @@ export class DarwinUpdateService extends AbstractUpdateService implements IRelau
 					this.logService.trace('[Update] Received GitHub response:', response);
 					const platform = `darwin-${process.arch}`;
 					this.logService.trace('[Update] Parsing GitHub response for platform:', platform);
-					const update = parseGitHubReleaseToUpdate(response, platform, this.productService);
+					const update = parseGitHubReleaseToUpdate(response, platform, this.productService, this.logService);
+					this.logService.trace('[Update] GitHub parsed update object:', update);
 
 					if (!update || !update.url || !update.version || !update.productVersion) {
 						this.logService.trace('[Update] No update available or invalid update data');

--- a/src/vs/platform/update/electron-main/updateService.linux.ts
+++ b/src/vs/platform/update/electron-main/updateService.linux.ts
@@ -56,7 +56,8 @@ export class LinuxUpdateService extends AbstractUpdateService {
 					// Parse GitHub release response
 					const platform = `linux-${process.arch}`;
 					this.logService.trace('[Update] Parsing GitHub response for platform:', platform);
-					update = parseGitHubReleaseToUpdate(response, platform, this.productService);
+					update = parseGitHubReleaseToUpdate(response, platform, this.productService, this.logService);
+					this.logService.trace('[Update] GitHub parsed update object:', update);
 				} else {
 					// Original Microsoft format
 					update = response;


### PR DESCRIPTION
This pull request introduces extensive improvements to the update services, primarily focused on enhancing logging and traceability throughout the update process for all supported platforms (Windows, Linux, and macOS). These changes will make it significantly easier to debug update-related issues by providing detailed trace logs at each step. Additionally, the version numbers in `package.json` and `product.json` have been updated.

**Update Service Logging Enhancements**

* Added detailed trace logging throughout the Windows update flow, including URL construction, update checks, asset selection, download progress, file cleanup, and installer launching. This will help diagnose and track the update process step-by-step. [[1]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422L111-R113) [[2]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422R127) [[3]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422L141-R145) [[4]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422R157-R192) [[5]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422R213) [[6]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422L209-R224) [[7]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422L220-R237) [[8]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422R261-R267) [[9]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422R282) [[10]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422R295-R298) [[11]](diffhunk://#diff-8003f46576363384b134dc9a8537b72257c476f0d1e080efe603f81176e91422R318)

* Improved logging in the GitHub release parsing and asset selection logic for all platforms, including explicit trace messages when skipping prereleases, selecting assets, and parsing release data. [[1]](diffhunk://#diff-24b9ddfee07113ace319175d46ce45efee589bdc13e769d200ab160d9b9b250aL42-R53) [[2]](diffhunk://#diff-24b9ddfee07113ace319175d46ce45efee589bdc13e769d200ab160d9b9b250aR68-R73) [[3]](diffhunk://#diff-24b9ddfee07113ace319175d46ce45efee589bdc13e769d200ab160d9b9b250aR87) [[4]](diffhunk://#diff-24b9ddfee07113ace319175d46ce45efee589bdc13e769d200ab160d9b9b250aR97-R105) [[5]](diffhunk://#diff-24b9ddfee07113ace319175d46ce45efee589bdc13e769d200ab160d9b9b250aR114) [[6]](diffhunk://#diff-24b9ddfee07113ace319175d46ce45efee589bdc13e769d200ab160d9b9b250aR123)

* Updated the macOS and Linux update services to pass the logging service into the GitHub release parser and log the resulting parsed update object for better visibility. [[1]](diffhunk://#diff-dc47920ff23914f2620f44dc1f93ac8ed3f7b580a76f6e4fd9e8f87259fce20eL119-R120) [[2]](diffhunk://#diff-5e40aa1b205d5e63142472e4789f5cc43d2427eaaccba2da7e0d8b6ad5c67e6eL59-R60)

**Version Updates**

* Bumped the application version in `package.json` and both the engine and product version in `product.json` to reflect the latest release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-285888428ebaab4e7985b695829cc9e47f98d2857505070ccacae3432b7b11dcL24-R25)