### PR TITLE
feat(siid-forge): add create namespace — scaffolds that cannot lose the meta file (2.16.0)

### DIFF
--- a/extensions/siid-forge/api/CHANGELOG.md
+++ b/extensions/siid-forge/api/CHANGELOG.md
@@ -21,6 +21,24 @@ field, safe), **major** = removal or changed signature (opt-in for consumers).
 
 ---
 
+## 2.16.0
+Added the `create` namespace: `apexClass`, `apexTrigger`, `lwc`, `aura` — local metadata
+scaffolding with no `sf` CLI dependency (the same files the Forge menu's Create commands write).
+
+Each builder writes the **complete bundle** — the `-meta.xml` companion always included — or
+throws without writing anything. This closes a real failure mode: an agent authoring files one
+at a time forgets the metadata companion, and an Apex class without its `.cls-meta.xml` cannot
+deploy. Observed in practice as a generated test class reported "deployed successfully" whose
+meta file was never written, so the class never reached the org. Here that is structurally
+impossible.
+
+Pass `body` to author real content in the same call (the meta companion is still generated, so
+one call yields a complete deployable pair); omit it for a stub. `files` overrides any other
+bundle member by relative path. An unrecognized `files` key throws rather than being ignored —
+a typo must never report success over an untouched stub.
+
+Additive; older consumers unaffected.
+
 ## 2.15.0
 `FormulaMultiResult` now documents `evaluated?`/`truncated?` in the public types (the runtime
 already returned them). Additive + optional; older consumers unaffected. Also corrected the

--- a/extensions/siid-forge/api/package.json
+++ b/extensions/siid-forge/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conscendotech/siid-forge-api",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Public TypeScript types for the SIID Forge extension SDK (ConscendoTechInc.siid-forge). Types only — the live API is bound at runtime via the installed extension's activate().",
   "types": "index.d.ts",
   "files": [

--- a/extensions/siid-forge/api/siid-forge.d.ts
+++ b/extensions/siid-forge/api/siid-forge.d.ts
@@ -296,6 +296,36 @@ export interface RecordEdit { recordId: string; fields: FieldEdit[]; /** Target 
 /** Per-record outcome of a save. */
 export interface RecordSaveResult { recordId: string; success: boolean; error?: string; }
 
+/** Options for every `create.*` builder. */
+export interface CreateOptions {
+  /** Project root. Defaults to the active workspace. */
+  projectRoot?: string;
+  /** Output directory (absolute, or relative to the project root). Defaults per type. */
+  outputDir?: string;
+  /** Metadata API version. Defaults to the project's, then the org's, then a built-in. */
+  apiVersion?: string;
+  /**
+   * Content for the PRIMARY file (`.cls`, `.trigger`, `.js`, `.cmp`). Omit for a
+   * stub. The `-meta.xml` companion is generated either way, so one call still
+   * yields a complete, deployable bundle.
+   */
+  body?: string;
+  /**
+   * Override any bundle file by its path relative to the bundle root (e.g.
+   * `MyCmp/MyCmp.html`). Applied after `body`. An unknown path throws rather than
+   * being ignored, so a typo can never report success over an untouched stub.
+   */
+  files?: Record<string, string>;
+}
+
+/** Result of a `create.*` call. `files` always includes the `-meta.xml`. */
+export interface CreateResult {
+  /** Absolute path of the primary file (the `.cls`, `.trigger`, `.js`, `.cmp`). */
+  primary: string;
+  /** Absolute paths of ALL files written, including the `-meta.xml`. */
+  files: string[];
+}
+
 /** One governor limit from a log's CUMULATIVE_LIMIT_USAGE block. */
 export interface LimitUsage { name: string; used: number; limit: number; /** used/limit as 0–100. */ percent: number; }
 /** A method/code-unit node in the log's execution tree, with self + total time. */
@@ -565,6 +595,23 @@ export interface SiidForgeApi {
       opts?: { projectRoot?: string },
       token?: CancellationToken
     ): Promise<RecordSaveResult[]>;
+  };
+
+  /**
+   * Local metadata scaffolding — no `sf` CLI. Each builder writes the COMPLETE
+   * bundle (the `-meta.xml` companion always included) or throws without writing
+   * anything, so a class can never land without the metadata file it needs to
+   * deploy. Pass `body` to author real content in the same call.
+   */
+  readonly create: {
+    /** Apex class (stub, or `body`) + its `.cls-meta.xml`. */
+    apexClass(name: string, opts?: CreateOptions): Promise<CreateResult>;
+    /** Apex trigger on `sobject` (stub, or `body`) + its `.trigger-meta.xml`. */
+    apexTrigger(name: string, sobject: string, opts?: CreateOptions): Promise<CreateResult>;
+    /** LWC bundle: `<name>/<name>.js`, `.html`, `.js-meta.xml`. */
+    lwc(name: string, opts?: CreateOptions): Promise<CreateResult>;
+    /** Aura bundle: `<name>/<name>.cmp`, `.cmp-meta.xml`, controller. */
+    aura(name: string, opts?: CreateOptions): Promise<CreateResult>;
   };
 
   readonly logs: {

--- a/extensions/siid-forge/src/api.ts
+++ b/extensions/siid-forge/src/api.ts
@@ -20,7 +20,10 @@ import { analyzeLog, analysisToMarkdown, AnalyzeOptions, LogAnalysis } from './c
 import { analyzeBatchJob, batchAnalysisToMarkdown, BatchJobAnalysis } from './core/replay/batchAnalyzer';
 import { collectBatchJobLogs, BatchJobLogs, CollectBatchOptions } from './core/batchLogs';
 import { saveRecordEdits, objectFromQuery, RecordEdit, RecordSaveResult } from './core/dataEditor';
+import { resolveApiVersion } from './core/workspace';
+import { apexClassScaffold, apexTriggerScaffold, lwcScaffold, auraScaffold, writeScaffold } from './core/scaffolds';
 import * as fs from 'fs';
+import * as path from 'path';
 import {
   diffMetadataTypes, disposeTypeDiff, applyMetadataToLocal, applyFromDiffGroups, retrieveTypesToLocal,
   isDiffableMetadataType, findOrphanedMetaFiles,
@@ -29,6 +32,41 @@ import {
 import { TraceManager } from './core/traceManager';
 import { Logger } from './core/logger';
 import { AiConfig } from './core/aiConfig';
+
+/**
+ * Result of a `create.*` call: the file to open/author next, plus every file the
+ * scaffold wrote. `files` always includes the companion `-meta.xml` — that is the
+ * point of the namespace, so callers can assert the pair landed.
+ */
+export interface CreateResult {
+  /** Absolute path of the primary file (the `.cls`, `.trigger`, `.js`, `.cmp`). */
+  primary: string;
+  /** Absolute paths of ALL files written, including the `-meta.xml`. */
+  files: string[];
+}
+
+/** Options for every `create.*` builder. */
+export interface CreateOptions {
+  /** Project root. Defaults to the active workspace. */
+  projectRoot?: string;
+  /** Output directory (absolute, or relative to the project root). Defaults per type. */
+  outputDir?: string;
+  /** Metadata API version. Defaults to the project's, then the org's, then a built-in. */
+  apiVersion?: string;
+  /**
+   * Content for the PRIMARY file (`.cls`, `.trigger`, `.js`, `.cmp`). Omit for the
+   * stub. The `-meta.xml` companion is generated either way, so passing `body`
+   * still yields a complete, deployable bundle in a single call.
+   */
+  body?: string;
+  /**
+   * Override any file in the bundle by its path relative to the bundle root
+   * (e.g. `MyCmp/MyCmp.html`, or `Foo.cls-meta.xml` to supply your own metadata).
+   * Applied after `body`. Unknown relative paths are rejected rather than
+   * silently ignored — a typo'd key must not look like a successful write.
+   */
+  files?: Record<string, string>;
+}
 
 /**
  * Public SDK surface for SIID Forge (plan §5.6 / §14 / §C). A stable, headless
@@ -83,8 +121,14 @@ export class SiidForgeApi {
    *          Batchable/Queueable job's many logs into one per-phase analysis).
    *  2.15.0 — `FormulaMultiResult` now documents `evaluated?`/`truncated?` in the
    *          public types (the runtime already returned them). Additive + optional;
-   *          older consumers unaffected. */
-  readonly version = '2.15.0';
+   *          older consumers unaffected.
+   *  2.16.0 — added `create` namespace: `apexClass`, `apexTrigger`, `lwc`, `aura`
+   *          (local metadata scaffolding, no `sf` CLI). Each writes the COMPLETE
+   *          bundle — the `-meta.xml` companion always included — or throws
+   *          without writing anything. Exposed because an agent authoring files
+   *          one at a time forgets the meta file, producing a class that cannot
+   *          deploy; here that failure is structurally impossible. Additive. */
+  readonly version = '2.16.0';
 
   constructor(
     private readonly sfExec: SfExecutor,
@@ -383,6 +427,108 @@ export class SiidForgeApi {
     ): Promise<RecordSaveResult[]> =>
       saveRecordEdits(this.sfExec, this.root(opts?.projectRoot), sobject, edits, token)
   };
+
+  // ──────────────────────────────── Create ────────────────────────────────
+  /**
+   * Local metadata scaffolding — the same files the Forge menu's "Create Apex
+   * Class / Trigger / LWC / Aura" commands write, exposed headlessly.
+   *
+   * WHY THIS IS ON THE API: an Apex class is not one file, it is a file PAIR —
+   * `Foo.cls` plus `Foo.cls-meta.xml`. A class without its meta file cannot be
+   * deployed. An agent authoring files one at a time reliably forgets the second
+   * one (observed: a generated test class deployed as "successful" while its
+   * meta file was never written, so the test class never reached the org).
+   *
+   * These builders make that failure structurally impossible: each returns the
+   * complete bundle, and `writeScaffold` pre-checks every target so a partial
+   * bundle is never written — it either creates the whole set or throws.
+   *
+   * CONTENT: pass `body` to write real code instead of the stub. The companion
+   * `-meta.xml` is still generated, so ONE call yields a complete, deployable
+   * pair. This matters for an agent: authoring is the natural thing to want from
+   * a "create" tool, and if `body` were ignored the caller would get a success
+   * result over an empty stub — a silent wrong-content failure that deploys
+   * cleanly and simply lacks the method. Omit `body` for a plain stub.
+   *
+   * For LWC/Aura, `body` fills the primary file (`.js` / `.cmp`); use `files` to
+   * override any other member of the bundle by its relative path.
+   *
+   * `apiVersion` defaults to the project's (`sfdx-project.json`), falling back to
+   * the org's, then a built-in default. `outputDir` defaults to the conventional
+   * location for the type and is resolved relative to the project root.
+   */
+  readonly create = {
+    /** Apex class (stub, or `body`) + its `.cls-meta.xml`. Returns the created paths. */
+    apexClass: async (name: string, opts?: CreateOptions): Promise<CreateResult> => {
+      const root = this.root(opts?.projectRoot);
+      const scaffold = apexClassScaffold(name, opts?.apiVersion ?? (await resolveApiVersion(root, this.orgMgr)));
+      return this.writeCreated(root, opts?.outputDir ?? 'force-app/main/default/classes', scaffold, opts);
+    },
+
+    /** Apex trigger on `sobject` (stub, or `body`) + its `.trigger-meta.xml`. */
+    apexTrigger: async (name: string, sobject: string, opts?: CreateOptions): Promise<CreateResult> => {
+      const root = this.root(opts?.projectRoot);
+      const scaffold = apexTriggerScaffold(name, sobject, opts?.apiVersion ?? (await resolveApiVersion(root, this.orgMgr)));
+      return this.writeCreated(root, opts?.outputDir ?? 'force-app/main/default/triggers', scaffold, opts);
+    },
+
+    /** LWC bundle: `<name>/<name>.js`, `.html`, and `.js-meta.xml`. */
+    lwc: async (name: string, opts?: CreateOptions): Promise<CreateResult> => {
+      const root = this.root(opts?.projectRoot);
+      const scaffold = lwcScaffold(name, opts?.apiVersion ?? (await resolveApiVersion(root, this.orgMgr)));
+      return this.writeCreated(root, opts?.outputDir ?? 'force-app/main/default/lwc', scaffold, opts);
+    },
+
+    /** Aura bundle: `<name>/<name>.cmp`, `.cmp-meta.xml`, and a controller. */
+    aura: async (name: string, opts?: CreateOptions): Promise<CreateResult> => {
+      const root = this.root(opts?.projectRoot);
+      const scaffold = auraScaffold(name, opts?.apiVersion ?? (await resolveApiVersion(root, this.orgMgr)));
+      return this.writeCreated(root, opts?.outputDir ?? 'force-app/main/default/aura', scaffold, opts);
+    }
+  };
+
+  /**
+   * Shared writer for the `create` namespace: applies any caller-supplied content,
+   * resolves the output dir, writes the bundle atomically, and reports the paths.
+   *
+   * Content substitution happens BEFORE writing, so the meta companion is still part
+   * of the same all-or-nothing bundle no matter what the caller overrode.
+   */
+  private writeCreated(
+    root: string,
+    outputDir: string,
+    scaffold: { files: { relPath: string; content: string }[]; primary: string },
+    opts?: CreateOptions
+  ): CreateResult {
+    const files = scaffold.files.map((f) => ({ ...f }));
+
+    if (opts?.body !== undefined) {
+      const primaryFile = files.find((f) => f.relPath === scaffold.primary);
+      if (!primaryFile) {
+        throw new Error(`SIID Forge API: scaffold has no primary file "${scaffold.primary}".`);
+      }
+      primaryFile.content = opts.body;
+    }
+
+    for (const [relPath, content] of Object.entries(opts?.files ?? {})) {
+      const target = files.find((f) => f.relPath === relPath);
+      if (!target) {
+        // Reject rather than ignore: a mistyped key would otherwise report success
+        // while writing the untouched stub.
+        throw new Error(
+          `SIID Forge API: "${relPath}" is not part of this bundle. Valid paths: ${files.map((f) => f.relPath).join(', ')}`
+        );
+      }
+      target.content = content;
+    }
+
+    const baseDir = path.isAbsolute(outputDir) ? outputDir : path.join(root, outputDir);
+    const primary = writeScaffold(baseDir, { files, primary: scaffold.primary });
+    return {
+      primary,
+      files: files.map((f) => path.join(baseDir, f.relPath))
+    };
+  }
 
   readonly logs = {
     /**


### PR DESCRIPTION
## Problem

An Apex class is not one file, it is a **pair**: `Foo.cls` plus `Foo.cls-meta.xml`.
A class without its meta file cannot be deployed.

An agent authoring files one at a time reliably forgets the companion. Observed in a
real session:

1. `RatingService.cls` written ✅
2. `RatingService.cls-meta.xml` written ✅
3. `RatingServiceTest.cls` written ✅
4. `RatingServiceTest.cls-meta.xml` — **never written** ❌

The deploy then reported `✅ DEPLOYMENT SUCCESSFUL` while the test class silently
never reached the org. Nothing in the pipeline detected the omission: the file
tracker listed the three written files as `created`, and the deploy simply skipped
the class it could not build.

The prompt rules are not the gap — `00-critical-salesforce-rules.md` already says
*"If creating a test class, also supply its `*-meta.xml`"* as rule #2. The model had
the instruction and still missed it. Whether a `.cls` has its meta file is a
deterministic, checkable invariant; relying on prompt compliance for it is the
design flaw.

## What this does

The scaffolding that gets this right already existed — the Forge menu's
**Create Apex Class / Trigger / LWC / Aura** commands use `core/scaffolds.ts`. The
AI just could not reach it. This exposes it headlessly on the public API:

```ts
forge.create.apexClass(name, opts?)         // .cls + .cls-meta.xml
forge.create.apexTrigger(name, sobject, ?)  // .trigger + .trigger-meta.xml
forge.create.lwc(name, opts?)               // .js + .html + .js-meta.xml
forge.create.aura(name, opts?)              // .cmp + .cmp-meta.xml + controller
```

Each builder writes the **complete bundle or nothing** — `writeScaffold` pre-checks
every target up front, so a half-written bundle is impossible and the meta file is
never a separate decision the model can skip.

### Authoring in one call

`body` writes real content instead of the stub, and the meta companion is still
generated:

```ts
await forge.create.apexClass("RatingService", { body: "public with sharing class ..." })
// -> { primary: ".../RatingService.cls",
//      files: [".../RatingService.cls", ".../RatingService.cls-meta.xml"] }
```

This is load-bearing rather than convenience. Without it the API would take a
body-shaped argument, silently drop it, and return **success over an empty stub** —
a file that deploys cleanly and simply lacks the method. That failure is worse than
the one being fixed, because it is invisible.

`files` overrides any other bundle member by relative path. An unrecognized key
**throws** rather than being ignored, so a typo can never report success over an
untouched stub.

## Scope / limits

- Guarantees **structural completeness**, not generated logic. The body still has to
  be correct — this stops a class from being undeployable, not from being wrong.
- Additive only. No existing signature changed; older consumers are unaffected.
- Nothing consumes it yet. SIID-Code wiring (`REQUIRED_FORGE_VERSION` → 2.16.0 plus a
  `siid_forge` registry entry) is a follow-up in the SIID-Code repo.

## API version

`2.15.0` → **`2.16.0`** (additive). Bumped in `src/api.ts`, `api/package.json`, and
documented in `api/CHANGELOG.md`; `scripts/check-api-version.js` green.

## Verification

- `tsc --noEmit` clean
- `check-api-version` — SDK types and runtime both at 2.16.0
- Existing forge tests pass (`deployDiff.managed.test.js`)
- 10 functional checks: body written (not stub), meta still generated alongside a
  body, `result.files` reports both paths, unknown `files` key rejected **with
  nothing written**, LWC bundle intact (`.js` + `.html` + `.js-meta.xml`), stub path
  still works when `body` is omitted

## Files

```
extensions/siid-forge/src/api.ts            +150/-1   create namespace + writeCreated
extensions/siid-forge/api/siid-forge.d.ts   +47       CreateOptions / CreateResult
extensions/siid-forge/api/CHANGELOG.md      +18       2.16.0 entry
extensions/siid-forge/api/package.json      +1/-1     2.15.0 -> 2.16.0
```

> The public `.d.ts` is mirrored to the `siid-forge-api` repo by its `sync.yml`
> Action. Per `SYNC-WORKFLOW.md`, the mirror should also publish a GitHub Release
> for the `v2.16.0` tag.