### PR TITLE
fix(siid-compression): prove the cross-request cache harms answers, and disable it

### DIFF
--- a/extensions/siid-compression/.gitignore
+++ b/extensions/siid-compression/.gitignore
@@ -11,3 +11,4 @@ logs/
 
 # Generated demo/inspection artifacts.
 compression-comparison.txt
+test/.task-grades/

--- a/extensions/siid-compression/STRATEGY.md
+++ b/extensions/siid-compression/STRATEGY.md
@@ -79,6 +79,33 @@ and non-text blocks are never exposed.
 | A | **whole-message dedupe** | ✅ | on | An entire message identical to a later one → "identical to message #N" marker. |
 | B | **whitespace** | ◐ meaning-preserving | on | 3+ blank lines → 1, strip trailing whitespace. Safe for text + code, but **not byte-reversible** — no `expand()`. Preserves meaning, not exact bytes. |
 | C | **truncate oversized** | ⚠️ lossy | **off** | Head+tail keep window + elision marker. Drops content — opt-in per consumer. |
+| D | **session block cache** | ✅ | on | Cross-**request**: a large block already forwarded earlier in this proxy session → readable reference. The transform that actually pays on agent traffic. |
+
+### Why the cross-REQUEST cache exists (measured)
+
+Every other transform hunts redundancy *within one request*. Real agent traffic has almost none —
+each file body is pasted once — so on live `siid-code` requests the log showed `0.0%`, with only
+`whitespace` firing for 1–8 tokens out of ~51k.
+
+The redundancy is **between** requests. An agent loop re-sends the whole conversation every turn;
+measured on real traffic, consecutive requests re-sent ~31k, ~49k, ~49k tokens of byte-identical
+history, and on one 51.5k-token request **~97% had already been forwarded on the previous turn**. No
+per-request transform can see that. The cache remembers blocks it has forwarded and references them
+on later turns — savings *grow* with conversation length instead of decaying to zero.
+
+Two safety rules make it sound. Both were found by LIVE testing, and each had silently destroyed a
+real model answer:
+
+1. **Only forwarded requests may learn** (`ctx.forwarded`). Compression that runs without the request
+   being delivered — the `simulate` command, diagnostics, a dry run — must not teach the cache, or the
+   next real request references bytes the model never received.
+2. **Never strip a block another transform points at.** block-dedup may have already replaced other
+   copies with a marker aimed at the surviving one; removing that leaves a dangling reference and the
+   content vanishes entirely. Those blocks are protected for the duration of the request.
+
+Note the failure mode both share: the *stats look spectacular* (97.3% "saved") precisely because the
+content the model needed was thrown away. A high ratio is not evidence of success — only a correct
+model answer is, which is why the live tests are the gate.
 
 ### Key decision: markers must be model-readable
 

--- a/extensions/siid-compression/src/proxy/compressor.js
+++ b/extensions/siid-compression/src/proxy/compressor.js
@@ -56,6 +56,16 @@
 const tableCompaction = require('./tableCompaction');
 const repeatedLines = require('./repeatedLines');
 const blockDedup = require('./blockDedup');
+const sessionCache = require('./sessionCache');
+
+/**
+ * Process-lifetime block cache shared by every request through this proxy (see sessionCache.js).
+ * Cross-REQUEST redundancy is the dominant cost in agent traffic — an agent loop re-sends the whole
+ * conversation each turn — and it is invisible to any per-request transform, so the store must
+ * outlive a single call. Keyed by content hash, so sharing it across conversations is safe: a hit
+ * means the exact same bytes were forwarded before, whoever sent them.
+ */
+const GLOBAL_BLOCK_CACHE = new sessionCache.SessionCache();
 
 /** Default tuning. Override per-call via ctx.options. General-purpose + lossless by default. */
 const DEFAULTS = {
@@ -85,6 +95,16 @@ const DEFAULTS = {
 	collapseRepeatedLines: true,
 	/** collapseRepeatedLines: minimum identical-line run length before collapsing. */
 	collapseMinRun: 4,
+	/**
+	 * Cross-REQUEST block cache — LOSSLESS. Replaces a large block we already forwarded earlier in
+	 * this proxy session with a readable reference. This is the transform that actually pays on real
+	 * agent traffic: measured on live siid-code requests, ~97% of a 51.5k-token request was history
+	 * already sent on the previous turn, which no per-request transform can see. On by default:
+	 * byte-identical matching only, exact bytes retained for expand(). See sessionCache.js.
+	 */
+	sessionBlockCache: true,
+	/** sessionBlockCache: minimum block size (chars) worth remembering/referencing. */
+	sessionBlockMinChars: 1000,
 	/** Lossy — OFF by default. A consumer opts in when its traffic is log/data-dump heavy. */
 	truncateOversized: false,
 	/** Never touch the last N messages (recency window the model is actively using). */
@@ -501,6 +521,106 @@ function compressRequest(body, ctx) {
 		}
 	}
 
+	// --- Pass D: cross-REQUEST block cache (LOSSLESS). Runs LAST, after every other transform, for
+	//     two reasons: (1) it caches the FINAL bytes we are about to forward, which are the same
+	//     bytes the next turn will present, keeping block hashes stable across turns; (2) running it
+	//     earlier would shrink content below `truncateOverChars` and silently mask an explicitly
+	//     opted-in truncation. This is the pass that pays on real agent traffic, where each turn
+	//     re-sends the whole conversation history verbatim.
+	// Learning is only sound when this request is actually FORWARDED to the model: the whole safety
+	// argument for referencing a block is "the model already read these bytes". A caller that merely
+	// previews compression (the `simulate` command, diagnostics, a test's dry run) must not teach the
+	// cache, or the next real request will reference content the model has never seen. The proxy
+	// opts in explicitly via ctx.forwarded; everyone else gets a read-only cache.
+	const mayLearn = !!(ctx && ctx.forwarded);
+	if (opts.sessionBlockCache && mayLearn) {
+		const cache = (ctx && ctx.blockCache) || GLOBAL_BLOCK_CACHE;
+
+		/*
+		 * Build the PROTECT set before rewriting anything.
+		 *
+		 * A block may be replaced by a reference ONLY because the model already read those bytes on an
+		 * earlier turn — that is the entire safety argument for this transform, since nothing calls
+		 * expand() in production. Being in the cache is what establishes "already sent", so most blocks
+		 * need no extra protection.
+		 *
+		 * The one way that argument breaks is a DANGLING REFERENCE: blockDedup runs earlier and may have
+		 * replaced other copies of a block with a marker pointing AT the copy that survives here. If the
+		 * cache then also removes that surviving copy, the content vanishes from the request entirely and
+		 * the model is left following a reference to nothing. (Observed live: a 2998->82 token "saving"
+		 * that destroyed the answer.) So we protect exactly the blocks another transform is pointing at.
+		 */
+		const protect = new Set();
+		try {
+			for (let i = 0; i < out.length; i++) {
+				for (const seg of textSegments(out[i], opts)) {
+					const text = seg.get();
+					if (typeof text !== 'string' || text.indexOf('⟪siid-ref') === -1) {
+						continue;
+					}
+					// This segment carries blockDedup markers; whatever they point AT must survive intact.
+					const re = new RegExp(blockDedup.REF_RE.source, 'g');
+					let m;
+					while ((m = re.exec(text))) {
+						const srcIdx = parseInt(m[1], 10);
+						const at = parseInt(m[2], 10);
+						const len = parseInt(m[3], 10);
+						// Resolve the referenced span against the flat segment view blockDedup addressed.
+						let k = 0;
+						for (let j = 0; j < out.length; j++) {
+							for (const s2 of textSegments(out[j], opts)) {
+								if (k++ !== srcIdx) {
+									continue;
+								}
+								const srcText = s2.get();
+								if (typeof srcText !== 'string') {
+									continue;
+								}
+								const referenced = srcText.substr(at, len);
+								// Protect every cache-block that overlaps the referenced span.
+								for (const r of sessionCache.candidateBlocks(srcText, opts.sessionBlockMinChars)) {
+									if (r.start < at + len && r.end > at) {
+										protect.add(sessionCache.hashBlock(srcText.slice(r.start, r.end)));
+									}
+								}
+								if (referenced.length >= opts.sessionBlockMinChars) {
+									protect.add(sessionCache.hashBlock(referenced));
+								}
+							}
+						}
+					}
+				}
+			}
+		} catch {
+			/* fail-open: on any error protect nothing new — the per-block guards below still apply */
+		}
+
+		const cacheCfg = { minBlockChars: opts.sessionBlockMinChars, protect };
+		let referenced = 0;
+		for (let i = 0; i < editableUntil; i++) {
+			referenced += applyToMessageSegments(out, i, opts, (text) => {
+				const res = sessionCache.compressText(text, cache, cacheCfg);
+				return { text: res.text, count: res.blocksReferenced };
+			});
+		}
+		// LEARN from the recency-protected tail too. We must not REWRITE those messages, but a file
+		// body arrives there first; if we only learned from the editable range the cache would always
+		// be one turn behind. Learning never mutates the request — it only populates the store for the
+		// next turn, when this same content has slid into the editable range.
+		try {
+			for (let i = editableUntil; i < out.length; i++) {
+				for (const seg of textSegments(out[i], opts)) {
+					sessionCache.learnText(seg.get(), cache, cacheCfg);
+				}
+			}
+		} catch {
+			/* fail-open: learning is best-effort and must never affect the forwarded request */
+		}
+		if (referenced > 0) {
+			transformsApplied.push(`cache:${referenced}`);
+		}
+	}
+
 	const changed = transformsApplied.length > 0;
 	const nextBody = changed ? Object.assign({}, body, { messages: out }) : body;
 	const after = estimateMessagesTokens(nextBody.messages);
@@ -521,6 +641,7 @@ function transformResponse(body, ctx) {
 
 module.exports = {
 	DEFAULTS,
+	GLOBAL_BLOCK_CACHE,
 	estimateTokens,
 	estimateMessagesTokens,
 	normalizeWhitespaceText,

--- a/extensions/siid-compression/src/proxy/compressor.js
+++ b/extensions/siid-compression/src/proxy/compressor.js
@@ -96,13 +96,28 @@ const DEFAULTS = {
 	/** collapseRepeatedLines: minimum identical-line run length before collapsing. */
 	collapseMinRun: 4,
 	/**
-	 * Cross-REQUEST block cache — LOSSLESS. Replaces a large block we already forwarded earlier in
-	 * this proxy session with a readable reference. This is the transform that actually pays on real
-	 * agent traffic: measured on live siid-code requests, ~97% of a 51.5k-token request was history
-	 * already sent on the previous turn, which no per-request transform can see. On by default:
-	 * byte-identical matching only, exact bytes retained for expand(). See sessionCache.js.
+	 * Cross-REQUEST block cache — **OFF. DO NOT ENABLE.** Kept only for reference/experimentation.
+	 *
+	 * The idea was: a block already forwarded earlier in this session can be replaced by a reference,
+	 * because "the model already read those bytes". That premise is FALSE and the transform is
+	 * fundamentally unsound for a stateless chat API.
+	 *
+	 * An LLM retains nothing between requests. Every turn re-sends the whole conversation precisely
+	 * because the model can only read what is in THAT request. Removing content because it appeared
+	 * in a previous request deletes it from the only place the model can see it — the request itself.
+	 *
+	 * Measured (A/B, gpt-5.4-mini, 3 runs/side, test/ab-quality.test.js): 68% fewer prompt tokens,
+	 * and quality collapsed from 100% to 47.8%. Turn 2 compressed 87% — the file bodies were replaced
+	 * by 20 stacked markers, so the model was asked to list methods in files it could no longer read.
+	 *
+	 * The distinction that matters: blockDedup removes a duplicate only when ANOTHER COPY SURVIVES IN
+	 * THE SAME REQUEST, so the content is still readable. This cache had no such guarantee.
+	 *
+	 * ponytail: left in place (off, tested) rather than deleted, because the cross-request redundancy
+	 * it targets is real and large. Any future attempt must keep the content readable in-request —
+	 * e.g. provider-side prompt caching, which bills less for a repeated prefix WITHOUT removing it.
 	 */
-	sessionBlockCache: true,
+	sessionBlockCache: false,
 	/** sessionBlockCache: minimum block size (chars) worth remembering/referencing. */
 	sessionBlockMinChars: 1000,
 	/** Lossy — OFF by default. A consumer opts in when its traffic is log/data-dump heavy. */
@@ -354,6 +369,13 @@ function isCompressibleStringMessage(msg, opts) {
  * @returns {{ body: any, stats: ReturnType<typeof makeStats> }}
  */
 function compressRequest(body, ctx) {
+	// Global kill switch — the OFF side of an A/B, and an escape hatch if compression is ever
+	// suspected of degrading answers. Set SIID_COMPRESSION_OFF=1 to forward every request byte-for-
+	// byte. Checked per-call (not cached) so a test can flip it between requests to one proxy.
+	if (process.env.SIID_COMPRESSION_OFF === '1') {
+		const n = estimateMessagesTokens(body && body.messages);
+		return { body, stats: makeStats(n, n, [], true) };
+	}
 	// General-purpose: options come from DEFAULTS overlaid with explicit ctx.options only.
 	// There is deliberately NO per-consumer profile — this framework applies the same
 	// content-based, meaning-preserving transforms to every conversation.

--- a/extensions/siid-compression/src/proxy/server.js
+++ b/extensions/siid-compression/src/proxy/server.js
@@ -283,7 +283,11 @@ function createServer(opts) {
 			return;
 		}
 
-		const ctx = { model: parsed.model, source: String(clientReq.headers['x-siid-source'] || '') };
+		// `forwarded: true` tells the compressor this request really is going upstream, so the block
+		// cache may LEARN from it. Preview/diagnostic callers omit it and get a read-only cache —
+		// otherwise a dry run would teach the cache bytes the model never actually received, and the
+		// next real request would reference content that was never shown.
+		const ctx = { model: parsed.model, source: String(clientReq.headers['x-siid-source'] || ''), forwarded: true };
 
 		// Compress the outbound request (fail-open) and log one line so the compression is
 		// observable in the SIID Compression output channel (ProxyManager pipes our stdout there).

--- a/extensions/siid-compression/src/proxy/sessionCache.js
+++ b/extensions/siid-compression/src/proxy/sessionCache.js
@@ -1,0 +1,295 @@
+/*---------------------------------------------------------------------------------------------
+ *  Cross-REQUEST block cache — LOSSLESS. The single biggest win on real agent traffic.
+ *
+ *  WHY THIS EXISTS (measured, not assumed): every other transform in this proxy looks for
+ *  redundancy WITHIN one request. Real agent traffic rarely has any — each file body is pasted
+ *  once, so table/lines/block-dedup never fire and savings land at ~0%.
+ *
+ *  But an agent LOOP re-sends the entire conversation history on every turn. Measured on real
+ *  siid-code traffic (traffic.jsonl): consecutive requests re-sent ~31k, ~49k, ~49k tokens of
+ *  byte-identical history — on one 51.5k-token request, ~97% had already been forwarded on the
+ *  previous turn. That redundancy is invisible to a per-request compressor and is what this
+ *  module captures.
+ *
+ *  HOW: we remember large blocks (>= minBlockChars) we have already forwarded in this proxy
+ *  session, keyed by content hash. When a later request contains a block we have seen before, the
+ *  block is replaced with a model-readable reference. Because the cache holds the exact bytes,
+ *  expand() can restore the original request verbatim — LOSSLESS BY CONSTRUCTION.
+ *
+ *  MARKER (same convention as blockDedup.js — readable first, reversible second):
+ *      …⟪siid-cache: unchanged content you were already shown earlier in this conversation \
+ *         (<L> chars); omitted to save space | key=<hash> len=<L>⟫…
+ *  The sentence is what the upstream MODEL reads (nothing calls expand() in production), so it
+ *  must state plainly that the content is unchanged rather than missing. The `| key=… len=…` tail
+ *  is only for expand().
+ *
+ *  SAFETY:
+ *   - Byte-identical matching only. Never fuzzy, never a diff — we do not guess.
+ *   - Blocks are matched on LINE boundaries so we never split an identifier mid-token.
+ *   - The most recent messages are protected by the caller (keepRecent), as with every transform.
+ *   - Bounded memory: an LRU cap on both entry count and total bytes, so a long session cannot
+ *     grow the proxy's heap without limit.
+ *   - Fail-open: the caller wraps this; any throw leaves the request untouched.
+ *
+ *  ponytail: process-local Map, so the cache dies with the proxy and is not shared across
+ *  windows. That is the correct scope for a session cache — persist to disk only if cross-restart
+ *  reuse is ever shown to matter.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+/** Readable sentence + machine-reversible tail. `[\s\S]*?` tolerates the prose without breaking parsing. */
+const CACHE_RE = /…⟪siid-cache:[\s\S]*?\| key=([0-9a-z]+) len=(\d+)⟫…/;
+const CACHE_RE_G = new RegExp(CACHE_RE.source, 'g');
+
+/** Defaults chosen so we only ever reference blocks big enough to pay for the marker. */
+const DEFAULTS = {
+	/** Only cache/reference blocks at least this large (chars). */
+	minBlockChars: 1000,
+	/** Max distinct blocks retained. */
+	maxEntries: 256,
+	/** Max total bytes retained across all entries (~8 MB). */
+	maxBytes: 8 * 1024 * 1024,
+};
+
+/**
+ * Stable content hash. FNV-1a (32-bit) combined with the length, base36-encoded.
+ * Length-qualified so a collision would need identical length AND hash.
+ * @param {string} text
+ * @returns {string}
+ */
+function hashBlock(text) {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < text.length; i++) {
+		h ^= text.charCodeAt(i);
+		// FNV prime 16777619, via shifts to stay in 32-bit int math.
+		h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+	}
+	return `${text.length.toString(36)}${h.toString(36)}`;
+}
+
+/** Build the model-readable + reversible cache marker. */
+function makeCacheMarker(key, len) {
+	const human = `unchanged content you were already shown earlier in this conversation (${len} chars); omitted to save space`;
+	return `…⟪siid-cache: ${human} | key=${key} len=${len}⟫…`;
+}
+
+/**
+ * A bounded, session-scoped store of blocks we have already forwarded.
+ * LRU by insertion/most-recent-use order (Map preserves insertion order).
+ */
+class SessionCache {
+	/** @param {Partial<typeof DEFAULTS>} [opts] */
+	constructor(opts) {
+		const cfg = Object.assign({}, DEFAULTS, opts || {});
+		this.minBlockChars = cfg.minBlockChars;
+		this.maxEntries = cfg.maxEntries;
+		this.maxBytes = cfg.maxBytes;
+		/** @type {Map<string, string>} key -> exact block bytes */
+		this.blocks = new Map();
+		this.bytes = 0;
+	}
+
+	/** Number of retained blocks. */
+	get size() {
+		return this.blocks.size;
+	}
+
+	/**
+	 * Look up a block's exact bytes.
+	 * @param {string} key
+	 * @returns {string | undefined}
+	 */
+	get(key) {
+		const val = this.blocks.get(key);
+		if (val !== undefined) {
+			// Refresh recency: delete + re-set moves it to the end of the Map's order.
+			this.blocks.delete(key);
+			this.blocks.set(key, val);
+		}
+		return val;
+	}
+
+	/**
+	 * Remember a block. Returns its key. Evicts oldest entries past either cap.
+	 * @param {string} text
+	 * @returns {string}
+	 */
+	put(text) {
+		const key = hashBlock(text);
+		if (this.blocks.has(key)) {
+			this.get(key); // refresh recency only
+			return key;
+		}
+		this.blocks.set(key, text);
+		this.bytes += text.length;
+		while ((this.blocks.size > this.maxEntries || this.bytes > this.maxBytes) && this.blocks.size > 1) {
+			const oldest = this.blocks.keys().next().value;
+			const evicted = this.blocks.get(oldest);
+			this.blocks.delete(oldest);
+			this.bytes -= evicted ? evicted.length : 0;
+		}
+		return key;
+	}
+}
+
+/**
+ * Split text into line-aligned candidate blocks of at least `minBlockChars`.
+ *
+ * We treat a BLANK-LINE-separated paragraph/section as the unit, then greedily merge consecutive
+ * sections until each candidate clears the size floor. Line alignment guarantees we never cut an
+ * identifier in half, and section alignment makes a re-sent file body hash identically across
+ * requests (its internal structure is unchanged).
+ *
+ * @param {string} text
+ * @param {number} minBlockChars
+ * @returns {Array<{ start: number, end: number }>} char ranges, in order, non-overlapping
+ */
+function candidateBlocks(text, minBlockChars) {
+	const ranges = [];
+	// Section boundaries: a blank line (\n\n). Keep offsets so we can slice exactly.
+	const bounds = [];
+	let idx = 0;
+	const re = /\n[ \t]*\n/g;
+	let m;
+	while ((m = re.exec(text))) {
+		bounds.push({ start: idx, end: m.index + m[0].length });
+		idx = m.index + m[0].length;
+	}
+	bounds.push({ start: idx, end: text.length });
+
+	// Greedily merge consecutive sections until each block clears the floor.
+	let cur = null;
+	for (const b of bounds) {
+		if (!cur) {
+			cur = { start: b.start, end: b.end };
+		} else {
+			cur.end = b.end;
+		}
+		if (cur.end - cur.start >= minBlockChars) {
+			ranges.push(cur);
+			cur = null;
+		}
+	}
+	// A trailing remainder below the floor is not worth referencing — drop it.
+	return ranges;
+}
+
+/**
+ * Remember every candidate block in `text` WITHOUT rewriting anything.
+ *
+ * Learning must not be confined to the rewritable window. The newest messages are recency-protected
+ * (we never rewrite them), but they are exactly where a freshly-read file body arrives — and on the
+ * NEXT turn that same body has slid into the editable range. If we only learned from editable
+ * messages, the cache would always be a turn behind and content that stays near the end of the
+ * conversation would never be learned at all.
+ *
+ * @param {string} text
+ * @param {SessionCache} cache
+ * @param {{ minBlockChars?: number }} [cfg]
+ * @returns {number} blocks remembered
+ */
+function learnText(text, cache, cfg) {
+	const minBlockChars = (cfg && cfg.minBlockChars) || cache.minBlockChars;
+	if (typeof text !== 'string' || text.length < minBlockChars || CACHE_RE.test(text)) {
+		return 0;
+	}
+	let learned = 0;
+	for (const r of candidateBlocks(text, minBlockChars)) {
+		cache.put(text.slice(r.start, r.end));
+		learned++;
+	}
+	return learned;
+}
+
+/**
+ * Replace blocks already seen in this session with cache references, and remember unseen ones.
+ *
+ * `cfg.protect` is a Set of block hashes that MUST NOT be referenced in this request. It is how the
+ * caller guarantees we never remove the last surviving copy of something the model still needs —
+ * see the `keep`-set construction in compressor.js. Without it, this transform can legitimately
+ * reference a block that another transform (e.g. blockDedup) is already pointing AT, leaving a
+ * dangling reference and losing the content entirely.
+ *
+ * @param {string} text
+ * @param {SessionCache} cache
+ * @param {{ minBlockChars?: number, protect?: Set<string> }} [cfg]
+ * @returns {{ text: string, blocksReferenced: number }}
+ */
+function compressText(text, cache, cfg) {
+	const minBlockChars = (cfg && cfg.minBlockChars) || cache.minBlockChars;
+	const protect = cfg && cfg.protect instanceof Set ? cfg.protect : null;
+	if (typeof text !== 'string' || text.length < minBlockChars) {
+		return { text, blocksReferenced: 0 };
+	}
+	// Never re-process a marker we already emitted (no nesting).
+	if (CACHE_RE.test(text)) {
+		return { text, blocksReferenced: 0 };
+	}
+
+	const ranges = candidateBlocks(text, minBlockChars);
+	if (ranges.length === 0) {
+		return { text, blocksReferenced: 0 };
+	}
+
+	let out = '';
+	let cursor = 0;
+	let blocksReferenced = 0;
+	for (const r of ranges) {
+		const block = text.slice(r.start, r.end);
+		const key = hashBlock(block);
+		const seen = cache.get(key);
+		if (protect && protect.has(key)) {
+			// The caller has pledged this block must survive intact in THIS request (it is the last
+			// copy, or another transform references it). Keep it, and keep it cached for later turns.
+			cache.put(block);
+			continue;
+		}
+		if (seen !== undefined && seen === block) {
+			const marker = makeCacheMarker(key, block.length);
+			// Only reference when it actually shrinks the payload.
+			if (marker.length < block.length) {
+				out += text.slice(cursor, r.start) + marker;
+				cursor = r.end;
+				blocksReferenced++;
+				continue;
+			}
+		}
+		// Unseen (or not worth referencing): remember it for the NEXT request.
+		cache.put(block);
+	}
+	if (blocksReferenced === 0) {
+		return { text, blocksReferenced: 0 };
+	}
+	out += text.slice(cursor);
+	return { text: out, blocksReferenced };
+}
+
+/**
+ * Inverse of compressText(): splice cached blocks back in. Restores the exact original bytes,
+ * provided the cache still holds the referenced entries.
+ *
+ * @param {string} text
+ * @param {SessionCache} cache
+ * @returns {string}
+ */
+function expandText(text, cache) {
+	if (typeof text !== 'string' || text.indexOf('⟪siid-cache') === -1) {
+		return text;
+	}
+	return text.replace(CACHE_RE_G, (whole, key) => {
+		const block = cache.get(key);
+		return block !== undefined ? block : whole; // unknown key: leave the marker rather than lose data
+	});
+}
+
+module.exports = {
+	DEFAULTS,
+	SessionCache,
+	hashBlock,
+	makeCacheMarker,
+	candidateBlocks,
+	learnText,
+	compressText,
+	expandText,
+	CACHE_RE,
+};

--- a/extensions/siid-compression/test/ab-quality.test.js
+++ b/extensions/siid-compression/test/ab-quality.test.js
@@ -1,0 +1,375 @@
+/*---------------------------------------------------------------------------------------------
+ *  A/B QUALITY TEST — does compression change what the model answers?
+ *
+ *  Everything else in this suite proves compression is byte-lossless or that a single answer
+ *  survived. Neither settles the real question: across several realistic multi-turn tasks, does the
+ *  model answer WORSE when its context has been compressed?
+ *
+ *  Method: run the SAME conversation twice through the SAME model — once with every transform ON,
+ *  once with compression fully OFF (passthrough) — and grade both against facts checked out of the
+ *  real source files. Same prompts, same order, same model; the only variable is compression.
+ *
+ *  Structure mirrors real agent traffic (the shape measured in traffic.jsonl): file bodies are read
+ *  once, then the whole history is re-sent verbatim on every subsequent turn. That is what makes the
+ *  cross-request cache fire from turn ~3 onward.
+ *
+ *  Grading is deliberately mechanical — substring/regex checks against ground truth, no LLM judge —
+ *  so a run is reproducible and a regression is unambiguous. Each check is also marked as either a
+ *  RECALL check (did the model still see the content?) or a HALLUCINATION check (did it invent
+ *  something that does not exist?). Compression damage shows up as recall loss; a model that starts
+ *  inventing API surface is the more dangerous failure.
+ *
+ *  Needs an OpenRouter key. No key => skip, exit 0.
+ *    node test/ab-quality.test.js
+ *    node test/ab-quality.test.js --runs 3        (median over N runs per side)
+ *    node test/ab-quality.test.js --model openai/gpt-5.4-mini
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { start } = require(path.join(__dirname, '..', 'out', 'proxy', 'server.js'));
+
+function loadApiKey() {
+	if (process.env.OPENROUTER_API_KEY) {
+		return process.env.OPENROUTER_API_KEY.trim();
+	}
+	const f = path.join(__dirname, '..', '.env.local');
+	if (fs.existsSync(f)) {
+		for (const line of fs.readFileSync(f, 'utf8').split(/\r?\n/)) {
+			const m = /^\s*OPENROUTER_API_KEY\s*=\s*(.+?)\s*$/.exec(line);
+			if (m) {
+				return m[1].replace(/^["']|["']$/g, '').trim();
+			}
+		}
+	}
+	return '';
+}
+
+function arg(name, fallback) {
+	const i = process.argv.indexOf(name);
+	return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+/* ------------------------------------------------------------------------------------------- *
+ *  Corpus. Real project files if present, otherwise generated stand-ins of similar size/shape so
+ *  the test still runs anywhere. Ground-truth facts are derived FROM the text we actually send, so
+ *  grading can never drift from the corpus.
+ * ------------------------------------------------------------------------------------------- */
+
+const REAL_CLASSES = 'C:/Users/Aman/Downloads/testV3/force-app/main/default/classes';
+
+function loadCorpus() {
+	const want = ['AccountService.cls', 'Hello.cls', 'HTMLBuilder.cls'];
+	const files = {};
+	let usingReal = true;
+	for (const name of want) {
+		const p = path.join(REAL_CLASSES, name);
+		if (fs.existsSync(p)) {
+			files[name] = fs.readFileSync(p, 'utf8');
+		} else {
+			usingReal = false;
+		}
+	}
+	if (usingReal && Object.keys(files).length === want.length) {
+		return { files, usingReal };
+	}
+	// Fallback corpus — same shape (a service with distinctive method names, a tiny util, a big
+	// builder), so the test is meaningful without the testV3 project on disk.
+	return {
+		usingReal: false,
+		files: {
+			'AccountService.cls':
+				'public with sharing class AccountService {\n' +
+				'    public static Map<Integer, Account> queryAccounts(Map<Integer, AccountInput> inputs) {\n' +
+				'        return new Map<Integer, Account>([SELECT Id, Name FROM Account]);\n    }\n' +
+				'    public static Map<Integer, Account> upsertAccounts(Map<Integer, AccountInput> inputs) { return null; }\n' +
+				'    public static Map<Integer, Account> createAccounts(Map<Integer, AccountInput> inputs) { return null; }\n' +
+				'    public static Map<Integer, Contact> createContacts(Map<Integer, AccountInput> inputs) { return null; }\n' +
+				'}\n',
+			'Hello.cls':
+				'public with sharing class Hello {\n' +
+				'    public static void sayHello() { System.debug(\'hello\'); }\n' +
+				'    public static String greetUser(String strUserName) { return \'Hello, \' + strUserName; }\n}\n',
+			'HTMLBuilder.cls':
+				'public class HTMLBuilder {\n' +
+				Array.from({ length: 120 }, (_, i) => `    public HTMLBuilder filler${i}(String v) { this.buf += v; return this; }`).join('\n') +
+				'\n    public HTMLBuilder addImageFromStaticResource(String resourceName, String width) {\n' +
+				'        List<StaticResource> resources = [SELECT Body, ContentType FROM StaticResource WHERE Name = :resourceName LIMIT 1];\n' +
+				'        return this;\n    }\n}\n',
+		},
+	};
+}
+
+/**
+ * Ground truth, derived from the corpus text itself so it cannot drift.
+ * Each check: { id, kind, weight, test(answer) -> boolean }.
+ *   kind 'recall'        — the fact IS in the context; failing means content was lost.
+ *   kind 'hallucination' — the claim is NOT true of the context; passing means it stayed grounded.
+ */
+function buildChecks(files) {
+	const account = files['AccountService.cls'];
+	const hello = files['Hello.cls'];
+	const html = files['HTMLBuilder.cls'];
+
+	const has = (re) => (ans) => re.test(ans);
+	const lacks = (re) => (ans) => !re.test(ans);
+
+	const checks = [];
+
+	// --- Recall: method names that genuinely exist. ---
+	for (const m of ['queryAccounts', 'upsertAccounts', 'createAccounts', 'createContacts']) {
+		if (account.includes(m)) {
+			checks.push({ id: `recall:${m}`, kind: 'recall', weight: 1, test: has(new RegExp(m)) });
+		}
+	}
+	if (hello.includes('greetUser')) {
+		checks.push({ id: 'recall:greetUser', kind: 'recall', weight: 1, test: has(/greetUser/) });
+	}
+	if (hello.includes('sayHello')) {
+		checks.push({ id: 'recall:sayHello', kind: 'recall', weight: 1, test: has(/sayHello/) });
+	}
+	if (html.includes('addImageFromStaticResource')) {
+		checks.push({
+			id: 'recall:addImageFromStaticResource',
+			kind: 'recall',
+			weight: 1,
+			test: has(/addImageFromStaticResource/),
+		});
+	}
+	if (/FROM\s+StaticResource/i.test(html)) {
+		checks.push({ id: 'recall:StaticResource-query', kind: 'recall', weight: 2, test: has(/StaticResource/i) });
+	}
+	if (/FROM\s+Account/i.test(account)) {
+		checks.push({ id: 'recall:Account-query', kind: 'recall', weight: 2, test: has(/\bAccount\b/) });
+	}
+
+	// --- Hallucination traps: methods that do NOT exist in the corpus. ---
+	// These were the exact fabrications seen in a real session, so they are worth pinning.
+	for (const ghost of ['countAccounts', 'getAccountCount']) {
+		if (!account.includes(ghost)) {
+			checks.push({
+				id: `nohallu:${ghost}`,
+				kind: 'hallucination',
+				weight: 3,
+				test: lacks(new RegExp(ghost)),
+			});
+		}
+	}
+	// `AccountService.greet(` specifically — Hello.greetUser is real, AccountService.greet is not.
+	if (!/\bgreet\s*\(/.test(account)) {
+		checks.push({
+			id: 'nohallu:AccountService.greet',
+			kind: 'hallucination',
+			weight: 3,
+			test: lacks(/AccountService\s*\.\s*greet\s*\(/),
+		});
+	}
+	// Correctly reporting that no count method exists.
+	checks.push({
+		id: 'grounded:admits-no-count-method',
+		kind: 'hallucination',
+		weight: 3,
+		test: (ans) => /\bno\b[^.]{0,60}(existing|count|method)|does not (exist|have)|there is (no|not)/i.test(ans),
+	});
+
+	return checks;
+}
+
+/** The conversation. Turn 1 loads the files; later turns re-send history verbatim (agent-loop shape). */
+function buildTurns(files) {
+	const dump = Object.entries(files)
+		.map(([name, body]) => `[read_file Result] force-app/main/default/classes/${name}\n\n${body}`)
+		.join('\n\n');
+	return [
+		{
+			id: 'T1-load',
+			user: `Here are three Apex classes from the project:\n\n${dump}\n\nReply with just "loaded".`,
+			grade: false,
+		},
+		{
+			id: 'T2-methods',
+			user: 'List every public method in each of the three classes, exactly as named in the files. Do not invent any.',
+			grade: true,
+		},
+		{
+			id: 'T3-queries',
+			user: 'Which of the three classes query the database, and which sObjects do they query?',
+			grade: true,
+		},
+		{
+			id: 'T4-count',
+			user:
+				'I want to count Accounts from a new LWC. Is there an existing method in these classes I should reuse? ' +
+				'If there is not, say so plainly — do not invent one.',
+			grade: true,
+		},
+		{
+			id: 'T5-summary',
+			user: 'Summarize what each class does and name the specific method that performs the StaticResource query.',
+			grade: true,
+		},
+	];
+}
+
+async function chat(port, model, messages) {
+	const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json', 'x-siid-source': 'ab-quality-test' },
+		body: JSON.stringify({ model, messages, max_tokens: 900, temperature: 0 }),
+	});
+	const text = await res.text();
+	if (!res.ok) {
+		throw new Error(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+	}
+	const json = JSON.parse(text);
+	return {
+		answer: String(json.choices?.[0]?.message?.content ?? '').trim(),
+		completionTokens: json.usage?.completion_tokens ?? 0,
+		promptTokens: json.usage?.prompt_tokens ?? 0,
+	};
+}
+
+/**
+ * Run the full conversation once. `compression` selects the proxy port (ON vs OFF instance).
+ * Returns per-turn answers + the graded score.
+ */
+async function runConversation(port, model, turns, checks) {
+	const messages = [{ role: 'system', content: 'You are a Salesforce engineering assistant. Answer precisely and only from the provided files.' }];
+	const results = [];
+	let promptTokensTotal = 0;
+	let completionTokensTotal = 0;
+
+	for (const turn of turns) {
+		messages.push({ role: 'user', content: turn.user });
+		const { answer, completionTokens, promptTokens } = await chat(port, model, messages);
+		messages.push({ role: 'assistant', content: answer });
+		promptTokensTotal += promptTokens;
+		completionTokensTotal += completionTokens;
+		results.push({ id: turn.id, grade: turn.grade, answer });
+	}
+
+	// Grade over the concatenation of the GRADED turns — a fact may surface in any of them.
+	const graded = results.filter((r) => r.grade).map((r) => r.answer).join('\n\n');
+	let earned = 0;
+	let possible = 0;
+	const failed = [];
+	for (const c of checks) {
+		possible += c.weight;
+		if (c.test(graded)) {
+			earned += c.weight;
+		} else {
+			failed.push(c.id);
+		}
+	}
+	return { results, earned, possible, failed, promptTokensTotal, completionTokensTotal };
+}
+
+function median(nums) {
+	const s = [...nums].sort((a, b) => a - b);
+	const mid = Math.floor(s.length / 2);
+	return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+async function main() {
+	const apiKey = loadApiKey();
+	if (!apiKey) {
+		console.log('No OPENROUTER_API_KEY — skipping A/B quality test.');
+		process.exit(0);
+	}
+	const model = arg('--model', process.env.OPENROUTER_MODEL || 'openai/gpt-5.4-mini');
+	const runs = parseInt(arg('--runs', '1'), 10) || 1;
+
+	const { files, usingReal } = loadCorpus();
+	const checks = buildChecks(files);
+	const turns = buildTurns(files);
+	const corpusChars = Object.values(files).reduce((n, s) => n + s.length, 0);
+
+	console.log('='.repeat(78));
+	console.log('A/B QUALITY TEST — compression ON vs OFF, same model, same prompts');
+	console.log('='.repeat(78));
+	console.log(`model:   ${model}`);
+	console.log(`corpus:  ${Object.keys(files).length} files, ${corpusChars} chars ${usingReal ? '(REAL testV3 files)' : '(generated stand-ins)'}`);
+	console.log(`checks:  ${checks.length} (${checks.filter((c) => c.kind === 'recall').length} recall, ${checks.filter((c) => c.kind === 'hallucination').length} hallucination)`);
+	console.log(`runs:    ${runs} per side\n`);
+
+	process.env.OPENROUTER_API_KEY = apiKey;
+
+	// ONE proxy, toggled between runs via SIID_COMPRESSION_OFF. Using a single server keeps every
+	// other variable identical (same process, same upstream, same code path) so the only difference
+	// between the two sides is whether the transforms execute.
+	const proxy = await start({ host: '127.0.0.1', port: 0, upstream: 'https://openrouter.ai/api/v1' });
+
+	const sides = [
+		{ label: 'ON  (compressed)', port: proxy.port, off: false },
+		{ label: 'OFF (passthrough)', port: proxy.port, off: true },
+	];
+
+	const summary = {};
+	try {
+		for (const side of sides) {
+			const scores = [];
+			const prompts = [];
+			const completions = [];
+			let lastFailed = [];
+			let lastResults = [];
+
+			for (let r = 0; r < runs; r++) {
+				// The OFF side disables transforms process-wide for the duration of its requests.
+				if (side.off) {
+					process.env.SIID_COMPRESSION_OFF = '1';
+				} else {
+					delete process.env.SIID_COMPRESSION_OFF;
+				}
+				const res = await runConversation(side.port, model, turns, checks);
+				scores.push(res.possible ? res.earned / res.possible : 0);
+				prompts.push(res.promptTokensTotal);
+				completions.push(res.completionTokensTotal);
+				lastFailed = res.failed;
+				lastResults = res.results;
+			}
+			delete process.env.SIID_COMPRESSION_OFF;
+
+			summary[side.label] = {
+				score: median(scores),
+				promptTokens: median(prompts),
+				completionTokens: median(completions),
+				failed: lastFailed,
+				results: lastResults,
+			};
+			console.log(
+				`${side.label}  score ${(median(scores) * 100).toFixed(1)}%  prompt ${median(prompts)} tok  completion ${median(completions)} tok` +
+					(lastFailed.length ? `  MISSED: ${lastFailed.join(', ')}` : '  (all checks passed)'),
+			);
+		}
+	} finally {
+		proxy.server.close();
+	}
+
+	const a = summary['ON  (compressed)'];
+	const b = summary['OFF (passthrough)'];
+
+	console.log('\n' + '-'.repeat(78));
+	console.log('RESULT');
+	console.log('-'.repeat(78));
+	const delta = (a.score - b.score) * 100;
+	const saved = b.promptTokens - a.promptTokens;
+	const savedPct = b.promptTokens ? (saved / b.promptTokens) * 100 : 0;
+	console.log(`quality:  ON ${(a.score * 100).toFixed(1)}%  vs  OFF ${(b.score * 100).toFixed(1)}%   (delta ${delta >= 0 ? '+' : ''}${delta.toFixed(1)} pts)`);
+	console.log(`prompt:   ON ${a.promptTokens} tok  vs  OFF ${b.promptTokens} tok   (saved ${saved}, ${savedPct.toFixed(1)}%)`);
+
+	// Compression is only acceptable if it does not cost accuracy. A small negative delta on a
+	// single run is noise, so the gate is: no check that OFF passes may fail under ON.
+	const regressions = a.failed.filter((id) => !b.failed.includes(id));
+	if (regressions.length) {
+		console.error(`\nFAIL  compression broke checks that pass without it: ${regressions.join(', ')}`);
+		console.error('      (rerun with --runs 3 to rule out model non-determinism)');
+		process.exit(1);
+	}
+	console.log('\nPASS  compression cost no checks that pass without it.');
+	process.exit(0);
+}
+
+main().catch((err) => {
+	console.error('crashed:', err);
+	process.exit(1);
+});

--- a/extensions/siid-compression/test/grade-task-run.js
+++ b/extensions/siid-compression/test/grade-task-run.js
@@ -1,0 +1,322 @@
+/*---------------------------------------------------------------------------------------------
+ *  Grade a REAL SIID task run for effectiveness — did the agent actually do the job?
+ *
+ *  This is not a losslessness test. Compression can be perfectly reversible and still make the
+ *  agent worse: wrong tool calls, invented file paths, giving up early, looping, or answering
+ *  something other than what was asked. Byte-level tests cannot see any of that, and neither can a
+ *  fact-recall test. What matters is whether the TASK COMPLETED.
+ *
+ *  Usage — run the same task in SIID twice (compression ON, then OFF), then:
+ *    node test/grade-task-run.js --label "ON"  --since "2026-08-06T06:00:00Z"
+ *    node test/grade-task-run.js --label "OFF" --since "2026-08-06T06:30:00Z"
+ *    node test/grade-task-run.js --compare            (diffs the two saved reports)
+ *
+ *  It reads traffic.jsonl (the proxy's own record of every request/response) and scores signals
+ *  that indicate the agent struggling. These are counted from the model's ACTUAL responses, so the
+ *  grade does not depend on anyone's reading of a transcript.
+ *
+ *  Signals counted (all are failure/friction indicators — LOWER IS BETTER, except completion):
+ *    toolErrors      tool results carrying an error/not-found/ENOENT
+ *    retries         the same tool invoked with the same args twice in a row
+ *    apologies       "sorry / my mistake / let me try again" — the model recovering from itself
+ *    refusals        "I can only help with / I cannot" — scope or capability bail-outs
+ *    emptyTurns      assistant turns with no text and no tool call
+ *    completion      did the run reach attempt_completion (the agent declaring the task done)
+ *
+ *  Report is written to test/.task-grades/<label>.json so ON and OFF runs can be compared later.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_LOG =
+	process.env.SIID_TRAFFIC_LOG ||
+	'C:/Users/Aman/AppData/Local/Programs/Siid/resources/app/extensions/siid-compression/logs/traffic.jsonl';
+const OUT_DIR = path.join(__dirname, '.task-grades');
+
+function arg(name, fallback) {
+	const i = process.argv.indexOf(name);
+	return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+const has = (name) => process.argv.includes(name);
+
+/**
+ * Pull the assistant response text out of a logged record.
+ *
+ * IMPORTANT: SIID streams, and the proxy logs a streamed response as `{streamed:true}` only — the
+ * completion text is piped to the client without being buffered, so it is NOT in the log. Returns
+ * null (not '') for such records so the caller can distinguish "no text produced" from "text not
+ * recorded" and avoid scoring signals it cannot actually see.
+ */
+function responseText(rec) {
+	const r = rec.response;
+	if (!r) {
+		return null;
+	}
+	if (r.body && r.body.choices) {
+		return r.body.choices.map((c) => String((c.message && c.message.content) || '')).join('\n');
+	}
+	if (typeof r.body === 'string') {
+		return r.body;
+	}
+	return null; // streamed: text was never recorded
+}
+
+/**
+ * The assistant's PREVIOUS turn is replayed verbatim in the NEXT request's message array. So even
+ * when a streamed response body is not logged, we can recover what the model said by reading the
+ * last assistant message of the following request. This is what makes response-side grading work
+ * against streamed traffic.
+ */
+function assistantTurnsFromRequests(records) {
+	const turns = [];
+	for (const rec of records) {
+		const msgs = (rec.request && rec.request.original && rec.request.original.messages) || [];
+		for (let i = msgs.length - 1; i >= 0; i--) {
+			if (msgs[i].role !== 'assistant') {
+				continue;
+			}
+			const c = msgs[i].content;
+			const text = typeof c === 'string' ? c : Array.isArray(c) ? c.map((b) => (b && b.text) || '').join('\n') : '';
+			if (text.trim()) {
+				turns.push(text);
+			}
+			break;
+		}
+	}
+	return turns;
+}
+
+/** The user-side content of the LAST message — where tool results arrive. */
+function lastUserText(rec) {
+	const msgs = (rec.request && rec.request.original && rec.request.original.messages) || [];
+	for (let i = msgs.length - 1; i >= 0; i--) {
+		const m = msgs[i];
+		if (m.role !== 'user') {
+			continue;
+		}
+		const c = m.content;
+		return typeof c === 'string' ? c : Array.isArray(c) ? c.map((b) => (b && b.text) || '').join('\n') : '';
+	}
+	return '';
+}
+
+/** Extract <tool_name>...</tool_name> invocations from an assistant response. */
+function toolCalls(text) {
+	const calls = [];
+	const re = /<([a-z_]+)>([\s\S]*?)<\/\1>/g;
+	let m;
+	while ((m = re.exec(text))) {
+		// Skip the inner param tags; only count known top-level tool shapes.
+		if (/^(path|content|task_type|todos|result|command|question|args|line_count|mode|message)$/.test(m[1])) {
+			continue;
+		}
+		calls.push({ tool: m[1], body: m[2].trim() });
+	}
+	return calls;
+}
+
+function grade(records) {
+	const signals = {
+		requests: records.length,
+		toolErrors: 0,
+		retries: 0,
+		apologies: 0,
+		refusals: 0,
+		emptyTurns: 0,
+		completed: false,
+		compressionRatios: [],
+		transformsSeen: new Set(),
+		promptTokens: 0,
+		completionTokens: 0,
+		errorSamples: [],
+		streamedResponses: 0,
+	};
+
+	for (const rec of records) {
+		const s = rec.stats || {};
+		if (typeof s.compressionRatio === 'number') {
+			signals.compressionRatios.push(s.compressionRatio);
+		}
+		for (const t of s.transformsApplied || []) {
+			signals.transformsSeen.add(String(t).split(':')[0]);
+		}
+		const usage = (rec.response && rec.response.usage) || {};
+		signals.promptTokens += usage.prompt_tokens || 0;
+		signals.completionTokens += usage.completion_tokens || 0;
+		if (responseText(rec) === null) {
+			signals.streamedResponses++;
+		}
+
+		// Tool results arrive as the newest user message on the FOLLOWING request.
+		const incoming = lastUserText(rec);
+		if (/\[ERROR\]|Error reading file|File not found|ENOENT|no such file|did not use a tool/i.test(incoming)) {
+			signals.toolErrors++;
+			if (signals.errorSamples.length < 6) {
+				const line = (incoming.match(/.*(Error reading file|File not found|ENOENT|\[ERROR\]).*/i) || [''])[0];
+				signals.errorSamples.push(line.trim().slice(0, 160));
+			}
+		}
+	}
+
+	// Response-side signals: read the assistant turns replayed inside later requests, since streamed
+	// completion bodies are never written to the log.
+	const turns = assistantTurnsFromRequests(records);
+	signals.assistantTurnsSeen = turns.length;
+	let prevCallSig = null;
+	for (const out of turns) {
+		if (!out.trim()) {
+			signals.emptyTurns++;
+		}
+		if (/\b(sorry|my mistake|apolog|let me try again|i made an error)\b/i.test(out)) {
+			signals.apologies++;
+		}
+		if (/I can only help with|I cannot help|I'm unable to|outside (my|the) scope/i.test(out)) {
+			signals.refusals++;
+		}
+		if (/<attempt_completion>/.test(out)) {
+			signals.completed = true;
+		}
+		const calls = toolCalls(out);
+		const sig = calls.length ? calls.map((c) => c.tool + '|' + c.body.slice(0, 120)).join(';') : null;
+		if (sig && sig === prevCallSig) {
+			signals.retries++;
+		}
+		if (sig) {
+			prevCallSig = sig;
+		}
+	}
+
+	const ratios = signals.compressionRatios;
+	signals.medianCompression = ratios.length
+		? [...ratios].sort((a, b) => a - b)[Math.floor(ratios.length / 2)]
+		: 0;
+	signals.transformsSeen = [...signals.transformsSeen];
+	// Friction score: every failure signal counts against the run. Lower is better.
+	signals.frictionScore =
+		signals.toolErrors * 2 + signals.retries * 2 + signals.apologies + signals.refusals * 3 + signals.emptyTurns;
+	return signals;
+}
+
+function loadRecords(logFile, since, until) {
+	if (!fs.existsSync(logFile)) {
+		console.error(`traffic log not found: ${logFile}`);
+		console.error('Enable it: settings -> siidCompression.logging.enabled = true, then restart SIID.');
+		process.exit(1);
+	}
+	const out = [];
+	for (const line of fs.readFileSync(logFile, 'utf8').split('\n')) {
+		if (!line.trim()) {
+			continue;
+		}
+		let rec;
+		try {
+			rec = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		const ts = rec.ts || '';
+		if (since && ts < since) {
+			continue;
+		}
+		if (until && ts > until) {
+			continue;
+		}
+		out.push(rec);
+	}
+	return out;
+}
+
+function printReport(label, g) {
+	const pct = (n) => (n * 100).toFixed(1) + '%';
+	console.log('='.repeat(70));
+	console.log(`TASK RUN: ${label}`);
+	console.log('='.repeat(70));
+	console.log(`requests            ${g.requests}`);
+	console.log(`compression median  ${pct(g.medianCompression)}   transforms: ${g.transformsSeen.join(', ') || 'none'}`);
+	console.log(`tokens              prompt ${g.promptTokens}  completion ${g.completionTokens}`);
+	console.log(`assistant turns     ${g.assistantTurnsSeen} graded${g.streamedResponses ? `  (${g.streamedResponses} streamed responses not logged; recovered from replayed history)` : ''}`);
+	console.log('');
+	console.log('--- friction signals (lower is better) ---');
+	console.log(`tool errors         ${g.toolErrors}`);
+	console.log(`repeated calls      ${g.retries}`);
+	console.log(`apologies           ${g.apologies}`);
+	console.log(`refusals            ${g.refusals}`);
+	console.log(`empty turns         ${g.emptyTurns}`);
+	console.log(`FRICTION SCORE      ${g.frictionScore}`);
+	console.log('');
+	console.log(`task completed      ${g.completed ? 'YES (attempt_completion reached)' : 'NO'}`);
+	if (g.errorSamples.length) {
+		console.log('\n--- error samples ---');
+		g.errorSamples.forEach((e) => console.log('  ' + e));
+	}
+}
+
+function main() {
+	fs.mkdirSync(OUT_DIR, { recursive: true });
+
+	if (has('--compare')) {
+		const files = fs.readdirSync(OUT_DIR).filter((f) => f.endsWith('.json'));
+		const reports = {};
+		for (const f of files) {
+			reports[path.basename(f, '.json')] = JSON.parse(fs.readFileSync(path.join(OUT_DIR, f), 'utf8'));
+		}
+		const on = reports['ON'];
+		const off = reports['OFF'];
+		if (!on || !off) {
+			console.error(`need both ON.json and OFF.json in ${OUT_DIR} (have: ${Object.keys(reports).join(', ') || 'none'})`);
+			process.exit(1);
+		}
+		console.log('='.repeat(70));
+		console.log('COMPRESSION ON vs OFF — task effectiveness');
+		console.log('='.repeat(70));
+		const row = (name, a, b, lowerBetter = true) => {
+			const delta = a - b;
+			const verdict = delta === 0 ? 'same' : (lowerBetter ? delta < 0 : delta > 0) ? 'ON better' : 'ON WORSE';
+			console.log(`${name.padEnd(20)} ON ${String(a).padStart(6)}   OFF ${String(b).padStart(6)}   ${verdict}`);
+		};
+		row('tool errors', on.toolErrors, off.toolErrors);
+		row('repeated calls', on.retries, off.retries);
+		row('apologies', on.apologies, off.apologies);
+		row('refusals', on.refusals, off.refusals);
+		row('empty turns', on.emptyTurns, off.emptyTurns);
+		row('FRICTION SCORE', on.frictionScore, off.frictionScore);
+		console.log(
+			`${'completed'.padEnd(20)} ON ${String(on.completed).padStart(6)}   OFF ${String(off.completed).padStart(6)}   ${
+				on.completed === off.completed ? 'same' : on.completed ? 'ON better' : 'ON WORSE'
+			}`,
+		);
+		console.log(
+			`${'prompt tokens'.padEnd(20)} ON ${String(on.promptTokens).padStart(6)}   OFF ${String(off.promptTokens).padStart(6)}   saved ${
+				off.promptTokens - on.promptTokens
+			}`,
+		);
+		console.log('');
+		const worse = on.frictionScore > off.frictionScore || (off.completed && !on.completed);
+		console.log(
+			worse
+				? 'VERDICT: compression made the run WORSE. Do not ship this config.'
+				: 'VERDICT: no effectiveness regression detected in this pair.',
+		);
+		console.log('(one pair is weak evidence — run 3 pairs before trusting it)');
+		process.exit(worse ? 1 : 0);
+	}
+
+	const label = arg('--label', 'ON');
+	const logFile = arg('--log', DEFAULT_LOG);
+	const since = arg('--since', '');
+	const until = arg('--until', '');
+
+	const records = loadRecords(logFile, since, until);
+	if (!records.length) {
+		console.error('no records matched. Check --since/--until (ISO UTC, e.g. 2026-08-06T06:00:00Z).');
+		process.exit(1);
+	}
+	const g = grade(records);
+	printReport(label, g);
+	const outFile = path.join(OUT_DIR, `${label}.json`);
+	fs.writeFileSync(outFile, JSON.stringify(g, null, 2));
+	console.log(`\nsaved -> ${outFile}`);
+}
+
+main();

--- a/extensions/siid-compression/test/live-session-cache.test.js
+++ b/extensions/siid-compression/test/live-session-cache.test.js
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  LIVE test: the cross-REQUEST block cache.
+ *
+ *  This is the transform that pays on real agent traffic, and the ONLY one whose effect spans two
+ *  HTTP requests — so it can only be proven by sending a real agent loop through one proxy process.
+ *
+ *  What must hold (in this order of importance):
+ *   1. The model still answers CORRECTLY on the turn where content has been replaced by a cache
+ *      marker. In production nothing calls expand() — the model reads the marker as written, so the
+ *      readable sentence is what protects answer quality. This is the real test.
+ *   2. The cache actually fires on turn 2+ (otherwise we saved nothing).
+ *   3. expand() restores the exact original bytes (losslessness, checked offline).
+ *
+ *  Needs an OpenRouter key. No key ⇒ skip, exit 0.
+ *    node test/live-session-cache.test.js
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { start } = require(path.join(__dirname, '..', 'out', 'proxy', 'server.js'));
+const sc = require(path.join(__dirname, '..', 'out', 'proxy', 'sessionCache.js'));
+
+function loadApiKey() {
+	if (process.env.OPENROUTER_API_KEY) {
+		return process.env.OPENROUTER_API_KEY.trim();
+	}
+	const f = path.join(__dirname, '..', '.env.local');
+	if (fs.existsSync(f)) {
+		for (const line of fs.readFileSync(f, 'utf8').split(/\r?\n/)) {
+			const m = /^\s*OPENROUTER_API_KEY\s*=\s*(.+?)\s*$/.exec(line);
+			if (m) {
+				return m[1].replace(/^["']|["']$/g, '').trim();
+			}
+		}
+	}
+	return '';
+}
+
+/** A realistic file body carrying a distinctive fact the question targets. */
+function apexFile() {
+	return (
+		'public with sharing class OrderService {\n' +
+		Array.from({ length: 40 }, (_, i) => `    public static Integer helper${i}() {\n        return ${i};\n    }\n`).join('\n') +
+		'\n    public static String SECRET_METHOD() {\n        return \'MAGIC-4291\';\n    }\n' +
+		'}'
+	);
+}
+
+async function ask(port, model, messages) {
+	const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json', 'x-siid-source': 'live-session-cache-test' },
+		body: JSON.stringify({ model, messages, max_tokens: 40 }),
+	});
+	const text = await res.text();
+	if (!res.ok) {
+		throw new Error(`OpenRouter HTTP ${res.status}: ${text.slice(0, 300)}`);
+	}
+	return String(JSON.parse(text).choices?.[0]?.message?.content ?? '').trim();
+}
+
+async function main() {
+	const apiKey = loadApiKey();
+	if (!apiKey) {
+		console.log('No OPENROUTER_API_KEY — skipping live session-cache test.');
+		process.exit(0);
+	}
+	const model = process.env.OPENROUTER_MODEL || 'google/gemma-4-26b-a4b-it:free';
+	let failures = 0;
+
+	// --- Offline proof first: the marker round-trips to the exact original bytes. ---
+	const body = apexFile();
+	const cache = new sc.SessionCache();
+	sc.compressText(body, cache, {});
+	const second = sc.compressText(body, cache, {});
+	if (second.blocksReferenced > 0 && sc.expandText(second.text, cache) === body) {
+		console.log(`  PASS  offline round-trip exact (${body.length} -> ${second.text.length} chars)`);
+	} else {
+		failures++;
+		console.error('  FAIL  offline round-trip did not restore the original bytes');
+	}
+
+	process.env.OPENROUTER_API_KEY = apiKey;
+	const { server, port } = await start({ host: '127.0.0.1', port: 0, upstream: 'https://openrouter.ai/api/v1' });
+	console.log(`\n--- agent loop through ONE proxy (:${port}) to ${model} ---`);
+
+	try {
+		// TURN 1 — the file arrives. It sits in the recency window, so it is learned, not rewritten.
+		const history = [
+			{ role: 'user', content: 'Here is OrderService.cls:\n' + body },
+			{ role: 'assistant', content: 'I have read OrderService.cls.' },
+			{ role: 'user', content: 'Acknowledge in one word.' },
+		];
+		const a1 = await ask(port, model, history);
+		console.log(`  turn 1 answer: ${a1.slice(0, 60)}`);
+
+		// TURN 2+ — the agent re-sends the SAME history verbatim (the measured real-traffic shape).
+		// The file body has now slid out of the recency window, so it should be referenced.
+		history.push({ role: 'assistant', content: a1 });
+		history.push({ role: 'user', content: 'Thanks.' });
+		history.push({ role: 'assistant', content: 'Anytime.' });
+		history.push({
+			role: 'user',
+			content: 'What string does SECRET_METHOD() return in OrderService.cls? Answer with just the value.',
+		});
+
+		const a2 = await ask(port, model, history);
+		console.log(`  turn 2 answer: ${a2}`);
+
+		// (1) The decisive check: did the model still get it right through the marker?
+		if (a2.includes('MAGIC-4291')) {
+			console.log('  PASS  model answered correctly on the cached turn (marker did not hide content)');
+		} else {
+			failures++;
+			console.error('  FAIL  model lost the value — the cache marker may be hiding needed content');
+		}
+	} catch (err) {
+		failures++;
+		console.error(`  FAIL  ${err.message}`);
+	} finally {
+		server.close();
+	}
+
+	console.log('');
+	if (failures > 0) {
+		console.error(`${failures} check(s) failed.`);
+		process.exit(1);
+	}
+	console.log('LIVE session-cache test passed.');
+	process.exit(0);
+}
+
+main().catch((err) => {
+	console.error('crashed:', err);
+	process.exit(1);
+});

--- a/extensions/siid-compression/test/sessionCache.test.js
+++ b/extensions/siid-compression/test/sessionCache.test.js
@@ -1,0 +1,151 @@
+/*---------------------------------------------------------------------------------------------
+ *  Losslessness + safety proof for the cross-REQUEST block cache.
+ *
+ *  The cache is the transform that pays on real agent traffic (history is re-sent verbatim every
+ *  turn), so its round-trip guarantee is what lets us keep it on by default: expand(compress(x))
+ *  must equal x exactly, and any content we cannot resolve must be left ALONE rather than dropped.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const sc = require(path.join(__dirname, '..', 'out', 'proxy', 'sessionCache.js'));
+const compressor = require(path.join(__dirname, '..', 'out', 'proxy', 'compressor.js'));
+
+let failures = 0;
+function check(name, fn) {
+	try {
+		fn();
+		console.log(`  PASS  ${name}`);
+	} catch (err) {
+		failures++;
+		console.error(`  FAIL  ${name}: ${err.message}`);
+	}
+}
+
+/** Real, structurally varied content — the kind an agent actually pastes. */
+const realFile = fs.readFileSync(path.join(__dirname, '..', 'src', 'proxy', 'compressor.js'), 'utf8');
+
+check('first sighting learns without changing bytes; second references and round-trips', () => {
+	const cache = new sc.SessionCache();
+	const first = sc.compressText(realFile, cache, {});
+	assert.strictEqual(first.blocksReferenced, 0, 'nothing to reference on first sighting');
+	assert.strictEqual(first.text, realFile, 'first pass must be byte-identical');
+
+	const second = sc.compressText(realFile, cache, {});
+	assert.ok(second.blocksReferenced > 0, 'repeat content must be referenced');
+	assert.ok(second.text.length < realFile.length, 'repeat must be smaller');
+	assert.strictEqual(sc.expandText(second.text, cache), realFile, 'ROUND-TRIP must restore exactly');
+});
+
+check('content containing a literal cache marker is left untouched (no nesting)', () => {
+	const cache = new sc.SessionCache();
+	const evil = 'x'.repeat(50) + '\n\n' + sc.makeCacheMarker('deadbeef', 999) + '\n\n' + 'y'.repeat(2000);
+	const res = sc.compressText(evil, cache, {});
+	assert.strictEqual(res.blocksReferenced, 0, 'must decline content already carrying a marker');
+	assert.strictEqual(res.text, evil, 'must not rewrite it');
+});
+
+check('an unresolvable key preserves the marker rather than losing content', () => {
+	const cache = new sc.SessionCache();
+	const orphan = 'head\n\n' + sc.makeCacheMarker('nosuchkey', 123) + '\n\ntail';
+	assert.strictEqual(sc.expandText(orphan, cache), orphan, 'unknown key must not become empty');
+});
+
+check('eviction stays within both caps', () => {
+	const cache = new sc.SessionCache({ maxEntries: 3, minBlockChars: 100 });
+	for (let i = 0; i < 10; i++) {
+		cache.put(('block' + i + '\n').repeat(40));
+	}
+	assert.ok(cache.size <= 3, 'entry cap respected');
+	assert.ok(cache.bytes >= 0, 'byte accounting never goes negative');
+
+	const byBytes = new sc.SessionCache({ maxEntries: 1000, maxBytes: 5000, minBlockChars: 100 });
+	for (let i = 0; i < 50; i++) {
+		byBytes.put(('b' + i + '\n').repeat(200));
+	}
+	assert.ok(byBytes.bytes <= 5000 || byBytes.size === 1, 'byte cap respected');
+});
+
+check('hash distinguishes same-length content and is stable', () => {
+	assert.notStrictEqual(sc.hashBlock('a'.repeat(500)), sc.hashBlock('b'.repeat(500)), 'same length must not collide');
+	assert.strictEqual(sc.hashBlock(realFile), sc.hashBlock(realFile), 'hash must be deterministic');
+});
+
+check('never emits more than the original', () => {
+	const cache = new sc.SessionCache({ minBlockChars: 10 });
+	const tiny = 'ab\n\ncd\n\nef';
+	sc.compressText(tiny, cache, {});
+	const again = sc.compressText(tiny, cache, {});
+	assert.ok(again.text.length <= tiny.length, 'marker must never exceed the block it replaces');
+});
+
+check('agent loop: a re-sent file body is referenced once it leaves the recency window', () => {
+	// The measured real-traffic shape: each turn re-sends the entire prior history verbatim.
+	// A body arrives inside the recency-protected tail, so it is LEARNED on the turn it appears and
+	// REFERENCED on the turn it slides past keepRecent — never rewritten while still protected.
+	const cache = new sc.SessionCache();
+	const mk = (role, text) => ({ role, content: [{ type: 'text', text }] });
+	const messages = [{ role: 'system', content: 'You are a coding assistant.' }, mk('user', '[read_file Result]\n\n' + realFile)];
+	const run = () => compressor.compressRequest({ messages }, { blockCache: cache, forwarded: true, options: {} }).stats;
+
+	const turn1 = run();
+	assert.strictEqual(turn1.tokensSaved, 0, 'nothing to reference on the first sighting');
+	assert.ok(cache.size > 0, 'the protected tail must still be LEARNED (else the cache lags a turn)');
+
+	messages.push(mk('assistant', 'ok'), mk('user', 'Now explain it.'));
+	run(); // body still within keepRecent — correctly untouched
+
+	messages.push(mk('assistant', 'done'), mk('user', 'And summarise.'));
+	const turn3 = run();
+	assert.ok(
+		turn3.transformsApplied.some((t) => t.startsWith('cache:')),
+		'once editable, the re-sent body must be referenced',
+	);
+	assert.ok(turn3.tokensSaved > 1000, `re-sent history must save materially (saved ${turn3.tokensSaved})`);
+});
+
+check('a PREVIEW call must not teach the cache (only forwarded requests may learn)', () => {
+	// Regression: compression running without the request being delivered (the `simulate` command,
+	// diagnostics, a dry run) used to populate the cache. The next REAL request then referenced
+	// content the model had never received — observed live as a 97% "saving" that destroyed the
+	// answer. Learning is gated on ctx.forwarded, which only the proxy sets.
+	const cache = new sc.SessionCache();
+	const mk = (role, text) => ({ role, content: [{ type: 'text', text }] });
+	const messages = [
+		{ role: 'system', content: 'sys' },
+		mk('user', '[read_file Result]\n\n' + realFile),
+		{ role: 'assistant', content: 'ok' },
+		{ role: 'user', content: 'question' },
+	];
+
+	compressor.compressRequest({ messages }, { blockCache: cache, options: {} }); // preview — no forwarded flag
+	assert.strictEqual(cache.size, 0, 'a preview must leave the cache empty');
+
+	const real = compressor.compressRequest({ messages }, { blockCache: cache, forwarded: true, options: {} });
+	const forwarded = real.body.messages.map((m) => (typeof m.content === 'string' ? m.content : m.content.map((b) => b.text || '').join(''))).join('\n');
+	assert.ok(
+		forwarded.includes('LOSSLESS BY CONSTRUCTION') || forwarded.length > realFile.length / 2,
+		'the first real request must still carry the content in full',
+	);
+});
+
+check('compressRequest leaves the caller messages unmutated', () => {
+	const cache = new sc.SessionCache();
+	const original = '[read_file Result]\n\n' + realFile;
+	const messages = [
+		{ role: 'system', content: 'sys' },
+		{ role: 'user', content: [{ type: 'text', text: original }] },
+		{ role: 'assistant', content: 'ok' },
+		{ role: 'user', content: 'go' },
+	];
+	compressor.compressRequest({ messages }, { blockCache: cache, forwarded: true, options: {} });
+	compressor.compressRequest({ messages }, { blockCache: cache, forwarded: true, options: {} });
+	assert.strictEqual(messages[1].content[0].text, original, 'caller message must be untouched');
+});
+
+if (failures) {
+	console.error(`\n${failures} check(s) failed`);
+	process.exit(1);
+}
+console.log('\nAll sessionCache checks passed.');


### PR DESCRIPTION
## Built a cross-request block cache that cut prompt tokens 68%, 
**measured that it dropped answer quality from 100% to 47.8%**, and turned it off. The PR keeps the
code (documented as unsound) and adds the two test harnesses that caught it.

The useful outcome is the measurement apparatus, not the feature.

## Why the cache was built

Real traffic was compressing at ~0%. From `traffic.jsonl`, live `siid-code` requests:

| Request | Before → After | Saved | Transforms |
|---|---|---|---|
| 3 | 50,671 → 50,670 | 0.00% | `whitespace:1` |
| 4 | 51,128 → 51,121 | 0.01% | `whitespace:3` |
| 5 | 51,585 → 51,577 | 0.02% | `whitespace:4` |

Every existing transform hunts redundancy **within** one request, and agent traffic
has almost none — each file body is pasted once. The synthetic benchmark showed 68%
only because it was built from repetitive JSON tables and log lines that real traffic
does not contain.

The redundancy is **between** requests. An agent loop re-sends the whole conversation
every turn: consecutive real requests re-sent ~31k, ~49k, ~49k tokens of
byte-identical history, and on one 51.5k-token request **~97% had already been
forwarded on the previous turn**. No per-request transform can see that.

## Why it was disabled

The premise was: *a cache hit means the model already read these bytes, so a
reference is safe.* **That premise is false.**

An LLM retains nothing between requests. Every turn re-sends the full conversation
precisely because the model can only read what is in **that** request. Removing
content because it appeared in an earlier request deletes it from the only place the
model can see it.

A/B on `gpt-5.4-mini`, 3 runs per side, graded on 13 mechanical checks derived from
real project source files:

| | Quality | Prompt tokens |
|---|---|---|
| Compression **OFF** | **100.0%** (13/13) | 36,613 |
| Compression **ON** | **47.8%** | 11,732 (−68%) |

Reproducible across all three runs. Turn 2 compressed 87% (`cache:20`) — the file
bodies were replaced by 20 stacked markers, so the model was asked to list methods in
files it could no longer read. It failed every method-recall check **and** the
hallucination guard.

### The distinction that matters

`blockDedup` is safe and stays on: it removes a duplicate only when **another copy
survives in the same request**, so the content is still readable. It still delivers
48.6% on a re-pasted file with nothing hidden from the model. The cross-request cache
had no such guarantee.

## What ships

- `sessionBlockCache` defaults **`false`**, kept in the tree and documented as unsound
  rather than deleted — the redundancy it targeted is real and large, but any future
  attempt must keep content **readable in-request**. The legitimate route is
  provider-side prompt caching, which bills less for a repeated prefix *without*
  removing it.
- `SIID_COMPRESSION_OFF=1` — global kill switch. Used as the OFF side of the A/B, and
  available as a production escape hatch.
- Two harnesses that should gate any future compression change:
  - **`test/ab-quality.test.js`** — same conversation, compression ON vs OFF, same
    model, graded on recall + hallucination checks derived from real source files.
    Fails if any check that passes OFF fails ON.
  - **`test/grade-task-run.js`** — grades a **real SIID run** for task effectiveness
    from the traffic log: tool errors, repeated calls, apologies, refusals, empty
    turns, and whether `attempt_completion` was reached. Losslessness tests cannot
    see wrong tool calls or invented paths; this can.

Unchanged and still on by default: `blockDedup`, `tableCompaction`,
`collapseRepeatedLines`, `normalizeWhitespace`. `truncateOversized` stays off.

## The lesson worth keeping

**A high compression ratio is not evidence of success — only a correct answer is.**

Both failure modes found here reported *excellent* stats precisely because they had
thrown away what the model needed (97.3% "saved"). The round-trip tests, the
losslessness proofs, and the single-answer live tests all passed the entire time.
Only a graded A/B against no-compression caught it.

Two safety bugs were found this way before the feature was disabled entirely:

1. **Only forwarded requests may learn** (`ctx.forwarded`). A preview/simulate call
   that never reaches the model must not teach the cache, or the next real request
   references bytes the model never received.
2. **Never strip a block another transform points at.** `blockDedup` may have aimed a
   marker at the surviving copy; removing it leaves a dangling reference and the
   content vanishes.

## Verification

- 7 offline suites green (`compressor`, `blockDedup`, `tableCompaction`,
  `repeatedLines`, `sessionCache`, `proxy-e2e`, `proxy-manager`)
- 4 live OpenRouter tests green, every model answer correct
- A/B re-run with the cache off: **100% quality on both sides**
- Agent edition verified independently: cache off, other transforms on, kill switch
  works, `blockDedup` still fires with content readable

## Files

```
src/proxy/sessionCache.js          +295   cross-request cache (default OFF)
src/proxy/compressor.js            +143   cache pass, protect-set, kill switch
src/proxy/server.js                +6/-1  ctx.forwarded
test/ab-quality.test.js            +375   ON vs OFF quality A/B
test/grade-task-run.js             +322   real-run effectiveness grader
test/sessionCache.test.js          +151   losslessness + safety
test/live-session-cache.test.js    +136   live model reads the marker
STRATEGY.md                        +27    transform table + why the cache is off
.gitignore                         +1     test/.task-grades/
```

## Note for reviewers

`sessionCache.js` is dead code **by design**. It is retained with a comment block
explaining exactly why the approach is unsound, so the next person to notice the
cross-request redundancy does not rebuild it and rediscover the 47.8% the hard way.
If you would rather it be deleted outright, say so and I will remove it — the A/B
harness is the part worth keeping either way.