### PR TITLE
Install salesforce and java while installing IDE. (agent edition)

### DIFF
--- a/TESTING-INSTALLER.md
+++ b/TESTING-INSTALLER.md
@@ -1,0 +1,114 @@
+# Testing the Installer Dependency Page
+
+How to build and run the Windows installer to test the **"Required Dependencies"**
+wizard page (Salesforce CLI / Node.js / Java JDK detection + install flow).
+
+There are two ways to build, depending on what you need to test.
+
+---
+
+## Option A — Fast UI test (recommended for iterating)
+
+Compiles **only** the installer wizard (`build/win32/code.iss`) with a stub
+payload. Takes a couple of seconds. Use this to test the dependency page and
+install flow. **It does NOT contain a real IDE** — the wizard runs, but there's
+no product inside.
+
+### Build
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\test-installer.ps1
+```
+
+### Build and launch in one step
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\test-installer.ps1 -Run
+```
+
+### Output location
+
+```
+C:\Users\<you>\AppData\Local\Temp\siid-installer-test\out\SIIDSetup.exe
+```
+
+The script prints this path when it finishes. The `siid-installer-test` folder
+is **wiped and rebuilt on every run** — don't keep anything in it.
+
+> **Note:** Close any previously-run `SIIDSetup.exe` before rebuilding, or the
+> compile fails with *"The process cannot access the file… used by another
+> process"* (a file lock, not a code error).
+
+### Requirements
+
+- `node_modules\innosetup\bin\ISCC.exe` must exist (run `npm install` if missing).
+
+---
+
+## Option B — Real, installable IDE (full build)
+
+Produces the actual shippable installer with the real IDE inside. Slow
+(requires the app to be built first).
+
+```
+npx gulp vscode-win32-x64-user-setup
+```
+
+This is also what the **GitHub Actions "Build SIID (Testing)"** workflow runs.
+
+---
+
+## Testing on GitHub Actions builds
+
+If you download an installer from GitHub Actions, **match the artifact label to
+the branch you want**:
+
+| Artifact / filename label | Branch | Has the new dependency page? |
+| ------------------------- | ------ | ---------------------------- |
+| `installer-flow`          | `add-salesforce-cli` | ✅ Yes |
+| `siid-forge-main`         | `siid-forge` branch  | ❌ No |
+
+> ⚠️ Common mistake: running the `siid-forge-main` build and thinking the page
+> is missing. It's on the **`installer-flow`** build. Check the filename.
+
+---
+
+## What you'll see on the Required Dependencies page
+
+Three rows — **Salesforce CLI**, **Java JDK 17**, **Node.js LTS** — each with a
+colour-coded status tag and glyph:
+
+| State | Colour | Glyph | Meaning |
+| ----- | ------ | ----- | ------- |
+| `Installed (version)` | green | ✓ | Already present |
+| `Not found – will be installed` | amber | • | Missing, will install on Next |
+| `Installing via winget/npm… (Ns)` | navy | — | In progress (live counter) |
+| `Failed …` | red | ✗ | Install failed (with manual command) |
+
+### To see the *install* flow (not just green rows)
+
+If everything is already installed you'll only see three green ✓ rows. To
+exercise the live install path, remove one dependency first:
+
+```powershell
+npm uninstall -g @salesforce/cli    # then run the installer -> watch it reinstall
+```
+
+- **Salesforce CLI** installs via `npm install -g @salesforce/cli`.
+- **Java JDK** installs via winget (`Azul.Zulu.17.JDK`).
+- **Node.js** installs via winget (`OpenJS.NodeJS.LTS`).
+
+> Java and Node are machine-scope MSIs, so Windows will show a **UAC /
+> administrator prompt**. The installer warns about this up front — that's
+> expected, not a bug.
+
+---
+
+## Recovering the script if it "disappears"
+
+`test-installer.ps1` only exists on the **`add-salesforce-cli`** branch. If you
+switch branches it won't be in the folder. It is committed, so restore it with:
+
+```powershell
+git checkout add-salesforce-cli -- test-installer.ps1
+```

--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -1306,6 +1306,920 @@ begin
   Result := not IsBackgroundUpdate();
 end;
 
+// Salesforce CLI and JDK Download and Installation
+var
+  JdkInstallSucceeded: Boolean;
+  SfCliInstallSucceeded: Boolean;
+  TestPage: TWizardPage;
+  // Live status controls on the Dependency Check page
+  SfCliNameLabel: TNewStaticText;
+  SfCliStateLabel: TNewStaticText;
+  JavaNameLabel: TNewStaticText;
+  JavaStateLabel: TNewStaticText;
+  DepFooterLabel: TNewStaticText;
+  NodeNameLabel: TNewStaticText;
+  NodeStateLabel: TNewStaticText;
+  SfCliPresent: Boolean;
+  JavaPresent: Boolean;
+  NodePresent: Boolean;
+  // Multi-JDK selection (only surfaced when 2+ compatible JDKs are detected).
+  JdkComboBox: TNewComboBox;
+  DetectedJdkHomes: TArrayOfString;   { parallel to combo items; JAVA_HOME per entry }
+  DetectedJdkMajors: TArrayOfInteger; { parallel: major version per entry }
+  SelectedJavaHome: String;           { chosen JAVA_HOME to persist, '' = leave as-is }
+
+const
+  // Java JDK 17 and Node.js LTS are installed via Winget (automatic PATH setup).
+  ZULU_JDK_PACKAGE = 'Azul.Zulu.17.JDK';
+  JDK_TARGET_VERSION = '17';
+  NODEJS_PACKAGE = 'OpenJS.NodeJS.LTS';
+  // Salesforce has no official 'sf' Winget package; the supported install path
+  // is npm. (The old direct-download URL now returns HTTP 403.)
+  SFCLI_NPM_PACKAGE = '@salesforce/cli';
+
+function IsJavaInstalled(): Boolean;
+var
+  JavaHome: String;
+  JavaExe: String;
+  ResultCode: Integer;
+begin
+  Result := False;
+
+  // Check if JAVA_HOME is set in Machine environment
+  if RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'JAVA_HOME', JavaHome) then
+  begin
+    JavaExe := AddBackslash(JavaHome) + 'bin\java.exe';
+    if FileExists(JavaExe) then
+    begin
+      Log('Found existing Java installation at JAVA_HOME: ' + JavaHome);
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  // Check if JAVA_HOME is set in User environment
+  if RegQueryStringValue(HKCU, 'Environment', 'JAVA_HOME', JavaHome) then
+  begin
+    JavaExe := AddBackslash(JavaHome) + 'bin\java.exe';
+    if FileExists(JavaExe) then
+    begin
+      Log('Found existing Java installation at user JAVA_HOME: ' + JavaHome);
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  // Check if java.exe is accessible via PATH
+  if Exec('cmd.exe', '/C java -version', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if ResultCode = 0 then
+    begin
+      Log('Found Java in system PATH');
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  Log('No existing Java installation found');
+end;
+
+function IsNodeInstalled(): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Result := False;
+
+  // npm is what we actually need (to install the CLI); require both node and npm.
+  if Exec('cmd.exe', '/C node --version >nul 2>&1 && npm --version >nul 2>&1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if ResultCode = 0 then
+    begin
+      Log('Found Node.js and npm in system PATH');
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  Log('No existing Node.js/npm installation found');
+end;
+
+function GetInstalledNodeVersion(): String;
+var
+  ResultCode: Integer;
+  TempFile: String;
+  Lines: TArrayOfString;
+begin
+  Result := '';
+  TempFile := ExpandConstant('{tmp}\nodeversion.txt');
+
+  if Exec('cmd.exe', '/C node --version > "' + TempFile + '" 2>&1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if (ResultCode = 0) and FileExists(TempFile) then
+    begin
+      if LoadStringsFromFile(TempFile, Lines) then
+      begin
+        if GetArrayLength(Lines) > 0 then
+          Result := Trim(Lines[0]);
+        DeleteFile(TempFile);
+        Exit;
+      end;
+    end;
+  end;
+
+  DeleteFile(TempFile);
+end;
+
+function GetInstalledJavaVersion(): String;
+var
+  ResultCode: Integer;
+  TempFile: String;
+  Lines: TArrayOfString;
+begin
+  Result := '';
+  TempFile := ExpandConstant('{tmp}\javaversion.txt');
+
+  if Exec('cmd.exe', '/C java -version 2> "' + TempFile + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if FileExists(TempFile) then
+    begin
+      if LoadStringsFromFile(TempFile, Lines) then
+      begin
+        if GetArrayLength(Lines) > 0 then
+        begin
+          Result := Trim(Lines[0]);
+        end;
+        DeleteFile(TempFile);
+        Exit;
+      end;
+    end;
+  end;
+
+  DeleteFile(TempFile);
+end;
+
+{ Reads the major version (e.g. 17, 21) of the java.exe under the given JDK home.
+  Returns 0 if it can't be determined. Salesforce CLI needs 17+. }
+function GetJdkMajorVersion(const JavaHome: String): Integer;
+var
+  ResultCode: Integer;
+  TempFile: String;
+  Lines: TArrayOfString;
+  Line, VerStr: String;
+  P, Q: Integer;
+  JavaExe: String;
+begin
+  Result := 0;
+  JavaExe := AddBackslash(JavaHome) + 'bin\java.exe';
+  if not FileExists(JavaExe) then
+    Exit;
+
+  TempFile := ExpandConstant('{tmp}\jdkmajor.txt');
+  { Wrap the whole command line (program + redirect) in one outer quote pair so
+    cmd /C strips exactly that pair; nesting quotes around just the exe breaks
+    when a redirect follows, and every JDK path contains a space. }
+  if Exec('cmd.exe', '/C ""' + JavaExe + '" -version 2> "' + TempFile + '""', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if FileExists(TempFile) and LoadStringsFromFile(TempFile, Lines) and (GetArrayLength(Lines) > 0) then
+    begin
+      { First line looks like: openjdk version "17.0.10" 2024-01-16 }
+      Line := Lines[0];
+      P := Pos('"', Line);
+      if P > 0 then
+      begin
+        VerStr := Copy(Line, P + 1, Length(Line) - P);
+        Q := Pos('"', VerStr);
+        if Q > 0 then
+          VerStr := Copy(VerStr, 1, Q - 1);
+        { "1.8.0_x" (old scheme) -> major 8; "17.0.x" -> major 17 }
+        Q := Pos('.', VerStr);
+        if Q > 0 then
+        begin
+          if Copy(VerStr, 1, 2) = '1.' then
+          begin
+            VerStr := Copy(VerStr, 3, Length(VerStr));
+            Q := Pos('.', VerStr);
+            if Q > 0 then
+              VerStr := Copy(VerStr, 1, Q - 1);
+          end
+          else
+            VerStr := Copy(VerStr, 1, Q - 1);
+        end;
+        Result := StrToIntDef(Trim(VerStr), 0);
+      end;
+    end;
+  end;
+  DeleteFile(TempFile);
+end;
+
+{ Best-effort vendor name from a JDK install path, for friendlier labels. }
+function JdkVendorFromPath(const JavaHome: String): String;
+var
+  Lower: String;
+begin
+  Lower := Lowercase(JavaHome);
+  if Pos('zulu', Lower) > 0 then
+    Result := 'Azul Zulu'
+  else if (Pos('adoptium', Lower) > 0) or (Pos('temurin', Lower) > 0) then
+    Result := 'Eclipse Temurin'
+  else if Pos('microsoft', Lower) > 0 then
+    Result := 'Microsoft'
+  else if (Pos('corretto', Lower) > 0) or (Pos('amazon', Lower) > 0) then
+    Result := 'Amazon Corretto'
+  else if (Pos('jdk-', Lower) > 0) and (Pos('oracle', Lower) > 0) then
+    Result := 'Oracle'
+  else if Pos('liberica', Lower) > 0 then
+    Result := 'BellSoft Liberica'
+  else
+    Result := '';
+end;
+
+{ Adds a JDK home to the parallel arrays if it isn't already present, the java.exe
+  exists, and its major version meets the Salesforce CLI minimum (17+). }
+procedure AddJdkCandidate(const JavaHome: String; var Homes: TArrayOfString; var Labels: TArrayOfString);
+var
+  I, Major: Integer;
+  Normalized, Vendor, Lbl, FolderName: String;
+begin
+  if JavaHome = '' then
+    Exit;
+  Normalized := RemoveBackslash(JavaHome);
+  if not FileExists(AddBackslash(Normalized) + 'bin\java.exe') then
+    Exit;
+  { De-dupe (case-insensitive). }
+  for I := 0 to GetArrayLength(Homes) - 1 do
+    if CompareText(Homes[I], Normalized) = 0 then
+      Exit;
+
+  Major := GetJdkMajorVersion(Normalized);
+  if Major < 17 then
+  begin
+    Log('Skipping JDK (major ' + IntToStr(Major) + ', below 17): ' + Normalized);
+    Exit;
+  end;
+
+  I := GetArrayLength(Homes);
+  SetArrayLength(Homes, I + 1);
+  SetArrayLength(Labels, I + 1);
+  SetArrayLength(DetectedJdkMajors, I + 1);
+  Homes[I] := Normalized;
+  DetectedJdkMajors[I] := Major;
+  { Label: "Java 21  (Microsoft)  -  jdk-21.0.11.10-hotspot". Use just the JDK
+    folder name (not the full path) so the closed combo box and the dropdown
+    popup fit the same width without clipping. The full path still lives in
+    DetectedJdkHomes and is shown in the status/log. }
+  Vendor := JdkVendorFromPath(Normalized);
+  FolderName := ExtractFileName(Normalized);
+  if FolderName = '' then
+    FolderName := Normalized;   { fallback for odd paths (e.g. a drive root) }
+  Lbl := 'Java ' + IntToStr(Major);
+  if Vendor <> '' then
+    Lbl := Lbl + '  (' + Vendor + ')';
+  Lbl := Lbl + '  -  ' + FolderName;
+  Labels[I] := Lbl;
+  Log('Detected compatible JDK (major ' + IntToStr(Major) + '): ' + Normalized);
+end;
+
+{ Scans a vendor registry hive (e.g. Adoptium\JDK) whose subkeys are versions,
+  each with a \hotspot\MSI (or \JavaHome) value pointing at the install path. }
+procedure ScanVendorRegistry(RootKey: Integer; const BaseKey: String; var Homes: TArrayOfString; var Labels: TArrayOfString);
+var
+  Versions: TArrayOfString;
+  I: Integer;
+  JavaHome: String;
+begin
+  if not RegGetSubkeyNames(RootKey, BaseKey, Versions) then
+    Exit;
+  for I := 0 to GetArrayLength(Versions) - 1 do
+  begin
+    JavaHome := '';
+    { Adoptium/Temurin layout: <ver>\hotspot\MSI, value "Path". }
+    if RegQueryStringValue(RootKey, BaseKey + '\' + Versions[I] + '\hotspot\MSI', 'Path', JavaHome) then
+      AddJdkCandidate(JavaHome, Homes, Labels)
+    { JavaSoft (Oracle) layout: <ver>, value "JavaHome". }
+    else if RegQueryStringValue(RootKey, BaseKey + '\' + Versions[I], 'JavaHome', JavaHome) then
+      AddJdkCandidate(JavaHome, Homes, Labels);
+  end;
+end;
+
+{ Scans a parent directory (e.g. C:\Program Files\Java) for JDK subfolders. }
+procedure ScanJdkParentDir(const ParentDir: String; var Homes: TArrayOfString; var Labels: TArrayOfString);
+var
+  FindRec: TFindRec;
+begin
+  if not DirExists(ParentDir) then
+    Exit;
+  if FindFirst(AddBackslash(ParentDir) + '*', FindRec) then
+  begin
+    try
+      repeat
+        if ((FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY) <> 0)
+           and (FindRec.Name <> '.') and (FindRec.Name <> '..') then
+          AddJdkCandidate(AddBackslash(ParentDir) + FindRec.Name, Homes, Labels);
+      until not FindNext(FindRec);
+    finally
+      FindClose(FindRec);
+    end;
+  end;
+end;
+
+{ Builds the list of all detected compatible (17+) JDK homes across common
+  vendor registry keys and install directories. }
+procedure EnumerateJdks(var Homes: TArrayOfString; var Labels: TArrayOfString);
+var
+  CurrentHome: String;
+begin
+  SetArrayLength(Homes, 0);
+  SetArrayLength(Labels, 0);
+  SetArrayLength(DetectedJdkMajors, 0);
+
+  { Vendor registry keys (32- and 64-bit views handled by Inno automatically). }
+  ScanVendorRegistry(HKLM, 'SOFTWARE\Eclipse Adoptium\JDK', Homes, Labels);
+  ScanVendorRegistry(HKLM, 'SOFTWARE\Eclipse Foundation\JDK', Homes, Labels);
+  ScanVendorRegistry(HKLM, 'SOFTWARE\Azul Systems\Zulu', Homes, Labels);
+  ScanVendorRegistry(HKLM, 'SOFTWARE\Microsoft\JDK', Homes, Labels);
+  ScanVendorRegistry(HKLM, 'SOFTWARE\JavaSoft\JDK', Homes, Labels);
+  ScanVendorRegistry(HKLM, 'SOFTWARE\JavaSoft\Java Development Kit', Homes, Labels);
+
+  { Common install directories. }
+  ScanJdkParentDir(ExpandConstant('{commonpf}\Java'), Homes, Labels);
+  ScanJdkParentDir(ExpandConstant('{commonpf}\Eclipse Adoptium'), Homes, Labels);
+  ScanJdkParentDir(ExpandConstant('{commonpf}\Zulu'), Homes, Labels);
+  ScanJdkParentDir(ExpandConstant('{commonpf}\Microsoft'), Homes, Labels);
+
+  { Whatever JAVA_HOME currently points at (may be outside the above). }
+  if RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'JAVA_HOME', CurrentHome) then
+    AddJdkCandidate(CurrentHome, Homes, Labels);
+  if RegQueryStringValue(HKCU, 'Environment', 'JAVA_HOME', CurrentHome) then
+    AddJdkCandidate(CurrentHome, Homes, Labels);
+end;
+
+function GetInstalledSfCliVersion(): String;
+var
+  ResultCode: Integer;
+  TempFile: String;
+  Lines: TArrayOfString;
+begin
+  Result := '';
+  TempFile := ExpandConstant('{tmp}\sfversion.txt');
+
+  // Try 'sf' command first
+  if Exec('cmd.exe', '/C sf --version > "' + TempFile + '" 2>&1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if (ResultCode = 0) and FileExists(TempFile) then
+    begin
+      if LoadStringsFromFile(TempFile, Lines) then
+      begin
+        if GetArrayLength(Lines) > 0 then
+        begin
+          Result := Trim(Lines[0]);
+        end;
+        DeleteFile(TempFile);
+        Exit;
+      end;
+    end;
+  end;
+
+  // Try 'sfdx' command (legacy)
+  if Exec('cmd.exe', '/C sfdx --version > "' + TempFile + '" 2>&1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if (ResultCode = 0) and FileExists(TempFile) then
+    begin
+      if LoadStringsFromFile(TempFile, Lines) then
+      begin
+        if GetArrayLength(Lines) > 0 then
+        begin
+          Result := Trim(Lines[0]);
+        end;
+        DeleteFile(TempFile);
+        Exit;
+      end;
+    end;
+  end;
+
+  DeleteFile(TempFile);
+end;
+
+function IsSalesforceCliInstalled(): Boolean;
+var
+  ResultCode: Integer;
+  SfPath: String;
+  SfdxPath: String;
+begin
+  Result := False;
+
+  // Check if 'sf' command is available in PATH
+  if Exec('cmd.exe', '/C sf --version', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if ResultCode = 0 then
+    begin
+      Log('Found Salesforce CLI (sf) in system PATH');
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  // Check if 'sfdx' command is available in PATH (legacy)
+  if Exec('cmd.exe', '/C sfdx --version', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    if ResultCode = 0 then
+    begin
+      Log('Found Salesforce CLI (sfdx) in system PATH');
+      Result := True;
+      Exit;
+    end;
+  end;
+
+  // Check common installation paths
+  SfPath := ExpandConstant('{localappdata}\sf\bin\sf.exe');
+  if FileExists(SfPath) then
+  begin
+    Log('Found Salesforce CLI at: ' + SfPath);
+    Result := True;
+    Exit;
+  end;
+
+  SfdxPath := ExpandConstant('{localappdata}\sfdx\bin\sfdx.exe');
+  if FileExists(SfdxPath) then
+  begin
+    Log('Found Salesforce CLI (sfdx) at: ' + SfdxPath);
+    Result := True;
+    Exit;
+  end;
+
+  Log('No existing Salesforce CLI installation found');
+end;
+
+{ Colored state tag on the right of a dependency row. A status glyph is derived
+  from the colour so it always matches: green -> check, red -> cross,
+  olive (pending/action needed) -> bullet, others (e.g. navy "in progress") none. }
+procedure SetDepState(Lbl: TNewStaticText; const Text: String; Color: TColor);
+var
+  Glyph: String;
+begin
+  if Lbl = nil then
+    Exit;
+  if Color = clGreen then
+    Glyph := #$2713 + '  '        { check mark }
+  else if Color = clRed then
+    Glyph := #$2717 + '  '        { cross mark }
+  else if Color = clOlive then
+    Glyph := #$2022 + '  '        { bullet - needs attention / pending }
+  else
+    Glyph := '';                  { in-progress: no glyph, avoids flicker }
+  Lbl.Caption := Glyph + Text;
+  Lbl.Font.Color := Color;
+end;
+
+{ Builds one dependency row: a bold name label on the left and a state tag on
+  the right. Returns the state label so callers can update it live. }
+function CreateDepRow(const Name: String; Top: Integer;
+  var NameLbl: TNewStaticText; var StateLbl: TNewStaticText): Integer;
+begin
+  NameLbl := TNewStaticText.Create(TestPage);
+  NameLbl.Parent := TestPage.Surface;
+  NameLbl.Left := ScaleX(8);
+  NameLbl.Top := Top;
+  NameLbl.Width := ScaleX(150);
+  NameLbl.Height := ScaleY(18);
+  NameLbl.Font.Style := [fsBold];
+  NameLbl.Caption := Name;
+
+  StateLbl := TNewStaticText.Create(TestPage);
+  StateLbl.Parent := TestPage.Surface;
+  StateLbl.Left := ScaleX(160);
+  StateLbl.Top := Top;
+  StateLbl.Width := TestPage.SurfaceWidth - ScaleX(160);
+  StateLbl.Height := ScaleY(18);
+  StateLbl.Caption := '';
+
+  Result := Top + ScaleY(26);
+end;
+
+procedure InitializeWizard;
+var
+  SfCliVersion: String;
+  JavaVersion: String;
+  NodeVersion: String;
+  IntroLabel: TNewStaticText;
+  TopPosition: Integer;
+  JdkLabels: TArrayOfString;
+  JdkPickerLabel: TNewStaticText;
+  JdkIndex: Integer;
+  BestIndex: Integer;
+begin
+  SfCliInstallSucceeded := False;
+  JdkInstallSucceeded := False;
+
+  TestPage := CreateCustomPage(wpSelectTasks, 'Required Dependencies',
+    'AIpexium needs these tools for Salesforce development.');
+
+  // Intro line
+  IntroLabel := TNewStaticText.Create(TestPage);
+  IntroLabel.Parent := TestPage.Surface;
+  IntroLabel.Left := ScaleX(8);
+  IntroLabel.Top := 0;
+  IntroLabel.Width := TestPage.SurfaceWidth - ScaleX(8);
+  IntroLabel.Height := ScaleY(50);
+  IntroLabel.WordWrap := True;
+  IntroLabel.AutoSize := False;
+  IntroLabel.Caption := 'Setup checked your system for the tools below. Anything marked'
+    + ' "Will be installed" is set up automatically on the next step.';
+
+  TopPosition := ScaleY(60);
+
+  // Salesforce CLI row
+  SfCliPresent := IsSalesforceCliInstalled();
+  TopPosition := CreateDepRow('Salesforce CLI', TopPosition, SfCliNameLabel, SfCliStateLabel);
+  if SfCliPresent then
+  begin
+    SfCliVersion := GetInstalledSfCliVersion();
+    if SfCliVersion = '' then
+      SfCliVersion := 'detected';
+    SetDepState(SfCliStateLabel, 'Installed  (' + SfCliVersion + ')', clGreen);
+  end
+  else
+    SetDepState(SfCliStateLabel, 'Not found  -  will be installed', clOlive);
+
+  // Java JDK row (needs 17+, so don't hardcode "17" - a newer JDK may be active)
+  JavaPresent := IsJavaInstalled();
+  TopPosition := CreateDepRow('Java JDK 17+', TopPosition, JavaNameLabel, JavaStateLabel);
+
+  // Enumerate all compatible (17+) JDKs up front; the count decides whether the
+  // status line carries the version or the picker below does.
+  SelectedJavaHome := '';
+  EnumerateJdks(DetectedJdkHomes, JdkLabels);
+
+  if not JavaPresent then
+    SetDepState(JavaStateLabel, 'Not found  -  will be installed', clOlive)
+  else if GetArrayLength(DetectedJdkHomes) >= 2 then
+    { Detail lives in the dropdown below - keep the tag short. }
+    SetDepState(JavaStateLabel, 'Installed  (' + IntToStr(GetArrayLength(DetectedJdkHomes)) + ' found  -  choose below)', clGreen)
+  else
+  begin
+    JavaVersion := GetInstalledJavaVersion();
+    if JavaVersion = '' then
+      JavaVersion := 'detected';
+    SetDepState(JavaStateLabel, 'Installed  (' + JavaVersion + ')', clGreen);
+  end;
+
+  // If more than one compatible JDK (17+) is present, let the user pick which one
+  // Salesforce CLI should use. The choice is written to JAVA_HOME on install.
+  if GetArrayLength(DetectedJdkHomes) >= 2 then
+  begin
+    // Default to the highest major version (recommended for Salesforce CLI).
+    BestIndex := 0;
+    for JdkIndex := 1 to GetArrayLength(DetectedJdkMajors) - 1 do
+      if DetectedJdkMajors[JdkIndex] > DetectedJdkMajors[BestIndex] then
+        BestIndex := JdkIndex;
+
+    TopPosition := TopPosition + ScaleY(4);   { breathing room above the picker }
+
+    { Picker sits under the status column (Left=174) and is deliberately sized
+      wider than the surface's right edge, extending into the right page margin,
+      so the full "vendor - folder (recommended)" item text isn't clipped. Label
+      and combo share the same Left/Width so their edges line up. }
+    JdkPickerLabel := TNewStaticText.Create(TestPage);
+    JdkPickerLabel.Parent := TestPage.Surface;
+    JdkPickerLabel.Left := ScaleX(174);
+    JdkPickerLabel.Top := TopPosition;
+    JdkPickerLabel.Width := TestPage.SurfaceWidth - ScaleX(102);
+    JdkPickerLabel.Height := ScaleY(16);
+    JdkPickerLabel.Caption := 'Multiple JDKs found - choose which one Salesforce CLI should use';
+    TopPosition := TopPosition + ScaleY(20);
+
+    JdkComboBox := TNewComboBox.Create(TestPage);
+    JdkComboBox.Parent := TestPage.Surface;
+    JdkComboBox.Left := ScaleX(174);
+    JdkComboBox.Top := TopPosition;
+    JdkComboBox.Width := TestPage.SurfaceWidth - ScaleX(102);
+    JdkComboBox.Style := csDropDownList;
+    for JdkIndex := 0 to GetArrayLength(JdkLabels) - 1 do
+    begin
+      if JdkIndex = BestIndex then
+        JdkComboBox.Items.Add(JdkLabels[JdkIndex] + '   (recommended)')
+      else
+        JdkComboBox.Items.Add(JdkLabels[JdkIndex]);
+    end;
+    JdkComboBox.ItemIndex := BestIndex;
+    SelectedJavaHome := DetectedJdkHomes[BestIndex];
+    TopPosition := TopPosition + ScaleY(34);
+  end;
+
+  // Node.js row (required by the Salesforce CLI installer)
+  NodePresent := IsNodeInstalled();
+  TopPosition := CreateDepRow('Node.js LTS', TopPosition, NodeNameLabel, NodeStateLabel);
+  if NodePresent then
+  begin
+    NodeVersion := GetInstalledNodeVersion();
+    if NodeVersion = '' then
+      NodeVersion := 'detected';
+    SetDepState(NodeStateLabel, 'Installed  (' + NodeVersion + ')', clGreen);
+  end
+  else
+    SetDepState(NodeStateLabel, 'Not found  -  will be installed', clOlive);
+
+  // Footer: what happens next
+  TopPosition := TopPosition + ScaleY(12);
+  DepFooterLabel := TNewStaticText.Create(TestPage);
+  DepFooterLabel.Parent := TestPage.Surface;
+  DepFooterLabel.Left := ScaleX(8);
+  DepFooterLabel.Top := TopPosition;
+  DepFooterLabel.Width := TestPage.SurfaceWidth - ScaleX(8);
+  DepFooterLabel.Height := ScaleY(34);
+  DepFooterLabel.WordWrap := True;
+  DepFooterLabel.AutoSize := False;
+  if SfCliPresent and JavaPresent and NodePresent then
+    DepFooterLabel.Caption := 'All dependencies are ready. Click Next to continue.'
+  else
+    DepFooterLabel.Caption := 'Click Next to install the missing dependencies.'
+      + ' This can take a few minutes and needs an internet connection.';
+end;
+
+{ Installs a package via Winget and polls until VerifyCmd (a cmd.exe fragment
+  that exits 0 when the tool is available) succeeds, updating StateLbl live.
+  Returns True only when actually verified in this process. }
+function WingetInstallAndVerify(const PackageId, Label_, VerifyCmd: String;
+  StateLbl: TNewStaticText): Boolean;
+var
+  ResultCode: Integer;
+  ElapsedSeconds: Integer;
+  MaxWaitSeconds: Integer;
+begin
+  Result := False;
+  Log('Installing ' + PackageId + ' via Winget...');
+
+  SetDepState(StateLbl, 'Installing via Winget...', clNavy);
+  WizardForm.StatusLabel.Caption := 'Installing ' + Label_ + ' (this may take a few minutes)...';
+  WizardForm.ProgressGauge.Style := npbstMarquee;
+  WizardForm.Update;
+
+  try
+    if not Exec('cmd.exe', '/C winget install --id=' + PackageId
+        + ' --silent --accept-source-agreements --accept-package-agreements',
+        '', SW_HIDE, ewNoWait, ResultCode) then
+    begin
+      Log('Failed to launch Winget for ' + PackageId);
+      SetDepState(StateLbl, 'Failed - install manually: winget install ' + PackageId, clRed);
+      Exit;
+    end;
+
+    ElapsedSeconds := 0;
+    MaxWaitSeconds := 180;
+    while ElapsedSeconds < MaxWaitSeconds do
+    begin
+      Sleep(1000);
+      ElapsedSeconds := ElapsedSeconds + 1;
+
+      SetDepState(StateLbl, 'Installing via Winget... (' + IntToStr(ElapsedSeconds) + 's)', clNavy);
+      WizardForm.Update;
+
+      if (ElapsedSeconds mod 5) = 0 then
+      begin
+        if Exec('cmd.exe', '/C ' + VerifyCmd, '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+           and (ResultCode = 0) then
+        begin
+          Log(PackageId + ' verified after ' + IntToStr(ElapsedSeconds) + 's');
+          Result := True;
+          Break;
+        end;
+      end;
+    end;
+  finally
+    WizardForm.ProgressGauge.Style := npbstNormal;
+    WizardForm.StatusLabel.Caption := '';
+    WizardForm.Update;
+  end;
+end;
+
+{ Installs Zulu JDK 17 via Winget. Sets JdkInstallSucceeded and updates the row. }
+function InstallJavaJdk(): Boolean;
+begin
+  Result := WingetInstallAndVerify(ZULU_JDK_PACKAGE, 'Java JDK', 'java -version >nul 2>&1', JavaStateLabel);
+  if Result then
+  begin
+    JdkInstallSucceeded := True;
+    SetDepState(JavaStateLabel, 'Installed  (restart terminal to use in shell)', clGreen);
+  end
+  else
+    // Winget may have installed it but PATH isn't refreshed in this process.
+    SetDepState(JavaStateLabel, 'Installed - restart your terminal, then run: java -version', clOlive);
+end;
+
+{ Installs Node.js LTS via Winget. npm ships with Node, so verifying npm is enough. }
+function InstallNodeJs(): Boolean;
+begin
+  Result := WingetInstallAndVerify(NODEJS_PACKAGE, 'Node.js', 'npm --version >nul 2>&1', NodeStateLabel);
+  if Result then
+  begin
+    NodePresent := True;
+    SetDepState(NodeStateLabel, 'Installed', clGreen);
+  end
+  else
+    SetDepState(NodeStateLabel, 'Installed - restart your terminal, then run: node --version', clOlive);
+end;
+
+{ Installs the modern Salesforce CLI (sf) via npm. Requires npm on PATH.
+  Salesforce has no official Winget package and the old direct download now 403s. }
+function InstallSalesforceCli(): Boolean;
+var
+  ResultCode: Integer;
+  NpmReady: Boolean;
+  DoneFile: String;
+  DoneLines: TArrayOfString;
+  ElapsedSeconds: Integer;
+  NpmExitCode: Integer;
+begin
+  Result := False;
+  Log('Installing Salesforce CLI via npm...');
+
+  // npm must be reachable. If Node was just installed, PATH may not be refreshed
+  // in this process - detect that and guide the user instead of failing opaquely.
+  NpmReady := Exec('cmd.exe', '/C npm --version >nul 2>&1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+    and (ResultCode = 0);
+  if not NpmReady then
+  begin
+    Log('npm not available in installer process - cannot install SF CLI now');
+    SetDepState(SfCliStateLabel,
+      'Needs Node.js - restart, then run: npm install -g ' + SFCLI_NPM_PACKAGE, clOlive);
+    Exit;
+  end;
+
+  SetDepState(SfCliStateLabel, 'Installing via npm...', clNavy);
+  WizardForm.StatusLabel.Caption := 'Installing Salesforce CLI via npm (this may take a few minutes)...';
+  WizardForm.ProgressGauge.Style := npbstMarquee;
+  WizardForm.Update;
+
+  DoneFile := ExpandConstant('{tmp}\sfcli-npm-done.txt');
+  DeleteFile(DoneFile);
+  try
+    // Run npm non-blocking so we can show a live counter, writing the exit code
+    // to a sentinel file when it finishes (mirrors the Winget poll pattern).
+    if not Exec('cmd.exe', '/C (npm install --global ' + SFCLI_NPM_PACKAGE
+        + ' && echo 0 > "' + DoneFile + '") || echo 1 > "' + DoneFile + '"',
+        '', SW_HIDE, ewNoWait, ResultCode) then
+    begin
+      Log('Failed to launch npm');
+      SetDepState(SfCliStateLabel, 'Failed - run manually: npm install -g ' + SFCLI_NPM_PACKAGE, clRed);
+      Exit;
+    end;
+
+    ElapsedSeconds := 0;
+    while ElapsedSeconds < 600 do   { npm global install can be slow }
+    begin
+      Sleep(1000);
+      ElapsedSeconds := ElapsedSeconds + 1;
+      SetDepState(SfCliStateLabel, 'Installing via npm... (' + IntToStr(ElapsedSeconds) + 's)', clNavy);
+      WizardForm.Update;
+      if FileExists(DoneFile) then
+        Break;
+    end;
+
+    if not FileExists(DoneFile) then
+    begin
+      Log('npm install timed out');
+      SetDepState(SfCliStateLabel, 'Timed out - run manually: npm install -g ' + SFCLI_NPM_PACKAGE, clRed);
+      Exit;
+    end;
+
+    // npm finished; read its exit code from the sentinel.
+    NpmExitCode := 1;
+    if LoadStringsFromFile(DoneFile, DoneLines) and (GetArrayLength(DoneLines) > 0) then
+      NpmExitCode := StrToIntDef(Trim(DoneLines[0]), 1);
+    Log('npm install exited with code: ' + IntToStr(NpmExitCode));
+
+    if NpmExitCode <> 0 then
+    begin
+      SetDepState(SfCliStateLabel, 'Install failed - run manually: npm install -g ' + SFCLI_NPM_PACKAGE, clRed);
+      Exit;
+    end;
+
+    SfCliInstallSucceeded := True;
+    if Exec('cmd.exe', '/C sf --version >nul 2>&1', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+       and (ResultCode = 0) then
+    begin
+      Log('Salesforce CLI successfully installed and verified');
+      Result := True;
+      SetDepState(SfCliStateLabel, 'Installed', clGreen);
+    end
+    else
+    begin
+      // Installed by npm, but PATH not refreshed in this process yet.
+      Log('SF CLI installed but not yet on PATH in installer process');
+      SetDepState(SfCliStateLabel, 'Installed - restart your terminal to use "sf"', clOlive);
+    end;
+  finally
+    DeleteFile(DoneFile);
+    WizardForm.ProgressGauge.Style := npbstNormal;
+    WizardForm.StatusLabel.Caption := '';
+    WizardForm.Update;
+  end;
+end;
+
+{ Persists the user-selected JDK as JAVA_HOME so Salesforce CLI uses it, and
+  updates the row to reflect the choice. Writes machine scope (HKLM) when admin,
+  otherwise user scope (HKCU). The write is idempotent, so this always runs and
+  always refreshes the label - no "already set" short-circuit, which previously
+  left the label stale when the user changed the selection and came back. }
+procedure ApplySelectedJavaHome();
+var
+  Wrote: Boolean;
+begin
+  if SelectedJavaHome = '' then
+    Exit;
+
+  { Prefer machine scope; fall back to user scope for non-elevated installs.
+    Whichever succeeds, also keep the OTHER hive from overriding our choice:
+    if an HKLM JAVA_HOME exists it wins in new shells, so when we can only write
+    HKCU we still try to keep HKLM in sync (best-effort, ignored if denied). }
+  Wrote := RegWriteStringValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'JAVA_HOME', SelectedJavaHome);
+  if Wrote then
+    Log('Set machine JAVA_HOME to selected JDK: ' + SelectedJavaHome)
+  else
+  begin
+    Wrote := RegWriteStringValue(HKCU, 'Environment', 'JAVA_HOME', SelectedJavaHome);
+    if Wrote then
+      Log('Set user JAVA_HOME to selected JDK: ' + SelectedJavaHome);
+  end;
+
+  if Wrote then
+    SetDepState(JavaStateLabel, 'Using  ' + SelectedJavaHome + '  (restart terminal)', clGreen)
+  else
+    Log('Could not write JAVA_HOME (HKLM and HKCU both denied): ' + SelectedJavaHome);
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+
+  // Drive dependency installation from the Dependency Check page.
+  if (CurPageID = TestPage.ID) then
+  begin
+    // Re-checking each tool spawns java/node/sf/npm synchronously, which freezes
+    // the wizard for a second or two. Show a busy indicator so the delay between
+    // clicking Next and the page advancing doesn't look like a hang.
+    WizardForm.StatusLabel.Caption := 'Checking dependencies, please wait...';
+    WizardForm.ProgressGauge.Style := npbstMarquee;
+    if DepFooterLabel <> nil then
+      DepFooterLabel.Caption := 'Working... applying your selection and re-checking tools.';
+    WizardForm.Update;
+    try
+      // Capture the JDK the user picked (if the picker was shown) and make it the
+      // machine JAVA_HOME so Salesforce CLI uses it.
+      if (JdkComboBox <> nil) and (JdkComboBox.ItemIndex >= 0)
+         and (JdkComboBox.ItemIndex < GetArrayLength(DetectedJdkHomes)) then
+      begin
+        SelectedJavaHome := DetectedJdkHomes[JdkComboBox.ItemIndex];
+        ApplySelectedJavaHome();
+      end;
+
+      // Re-check in case something changed since the page was built.
+      JavaPresent := IsJavaInstalled();
+      NodePresent := IsNodeInstalled();
+      SfCliPresent := IsSalesforceCliInstalled();
+    finally
+      WizardForm.ProgressGauge.Style := npbstNormal;
+      WizardForm.StatusLabel.Caption := '';
+      WizardForm.Update;
+    end;
+
+    // Java (Zulu) and Node ship only as machine-scope MSIs, so Winget needs
+    // administrator rights. Warn once, up front, so the Windows elevation
+    // prompt that follows isn't a surprise.
+    if (not JavaPresent) or (not NodePresent) then
+    begin
+      MsgBox('Setup will now install Java JDK and Node.js.'#13#10#13#10
+        + 'These require administrator access, so Windows may ask for'
+        + ' permission (a User Account Control prompt).', mbInformation, MB_OK);
+    end;
+
+    if not JavaPresent then
+      InstallJavaJdk();
+
+    // Node must be installed before the CLI (npm ships with Node).
+    if not NodePresent then
+      InstallNodeJs();
+
+    if not SfCliPresent then
+      InstallSalesforceCli();
+
+    if not (JavaPresent and NodePresent and SfCliPresent) then
+      DepFooterLabel.Caption := 'Dependency setup finished. Restart any open terminal'
+        + ' so the new tools are picked up, then click Next to continue.';
+  end;
+end;
+
+
+
+
+
+
+
+
+
+
+
+
+
 // Don't allow installing conflicting architectures
 function InitializeSetup(): Boolean;
 var
@@ -1500,9 +2414,29 @@ procedure CurStepChanged(CurStep: TSetupStep);
 var
   UpdateResultCode: Integer;
 	StartServiceResultCode: Integer;
+  JavaHome: String;
 begin
   if CurStep = ssPostInstall then
   begin
+    // Log Salesforce CLI installation status
+    if SfCliInstallSucceeded then
+    begin
+      Log('Salesforce CLI was successfully installed during setup');
+    end;
+
+    // Log Java installation status
+    if JdkInstallSucceeded then
+    begin
+      if RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'JAVA_HOME', JavaHome) then
+      begin
+        Log('JAVA_HOME environment variable is set to: ' + JavaHome);
+      end
+      else
+      begin
+        Log('Warning: JAVA_HOME environment variable was not set by JDK installer');
+      end;
+    end;
+
     if IsBackgroundUpdate() then
     begin
       CreateMutex('{#AppMutex}-ready');

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -122,6 +122,8 @@ import { NativeMcpDiscoveryHelperService } from '../../platform/mcp/node/nativeM
 import { IWebContentExtractorService } from '../../platform/webContentExtractor/common/webContentExtractor.js';
 import { NativeWebContentExtractorService } from '../../platform/webContentExtractor/electron-main/webContentExtractorService.js';
 import ErrorTelemetry from '../../platform/telemetry/electron-main/errorTelemetry.js';
+import { setupSalesforceCliPath } from './salesforceCliSetup.js';
+import { setupJavaEnvironment } from './javaSetup.js';
 
 /**
  * The main VS Code application. There will only ever be one instance,
@@ -536,6 +538,16 @@ export class CodeApplication extends Disposable {
 		if (isWindows && win32AppUserModelId) {
 			app.setAppUserModelId(win32AppUserModelId);
 		}
+
+		// Setup Salesforce CLI PATH on Windows
+		// This configures the bundled Salesforce CLI to be available in the user's PATH
+		// for use in terminals and system commands
+		await setupSalesforceCliPath(this.logService, this.stateService);
+
+		// Setup Java environment (JDK/JRE)
+		// This detects and configures Java for Salesforce development
+		// Java may be installed by the Siid installer or already present on the system
+		await setupJavaEnvironment(this.logService, this.stateService);
 
 		// Fix native tabs on macOS 10.13
 		// macOS enables a compatibility patch for any bundle ID beginning with

--- a/src/vs/code/electron-main/javaSetup.ts
+++ b/src/vs/code/electron-main/javaSetup.ts
@@ -1,0 +1,214 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as path from 'path';
+import * as fs from 'fs';
+import { ILogService } from '../../platform/log/common/log.js';
+import { IStateService } from '../../platform/state/node/state.js';
+import { isWindows } from '../../base/common/platform.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Sets up the Java Development Kit environment for Salesforce development.
+ * This function:
+ * 1. Checks if Java is already available in the system
+ * 2. Detects JDK installed by the Siid installer
+ * 3. Detects system-wide Java installations
+ * 4. Sets JAVA_HOME and updates PATH for the current process
+ * 5. Only runs once per installation (tracked via state service)
+ *
+ * Priority order:
+ * 1. JAVA_HOME from Machine environment (set by installer)
+ * 2. JAVA_HOME from User environment
+ * 3. Java found in PATH
+ * 4. Standard installation locations
+ *
+ * @param logService - The log service for logging messages
+ * @param stateService - The state service for tracking whether setup has been completed
+ */
+export async function setupJavaEnvironment(logService: ILogService, stateService: IStateService): Promise<void> {
+	// Check if we've already set up Java
+	const isSetup = stateService.getItem<boolean>('java.environmentSetup');
+	if (isSetup) {
+		logService.trace('Java environment already configured, skipping setup');
+		return;
+	}
+
+	logService.info('Setting up Java environment...');
+
+	try {
+		// Method 1: Check JAVA_HOME from Machine environment (set by installer or system admin)
+		if (isWindows) {
+			const getJavaHomeCmd = `powershell -Command "[Environment]::GetEnvironmentVariable('JAVA_HOME', 'Machine')"`;
+			const { stdout: machineJavaHome } = await execAsync(getJavaHomeCmd);
+			const javaHome = machineJavaHome.trim();
+
+			if (javaHome && fs.existsSync(javaHome)) {
+				const javaExe = path.join(javaHome, 'bin', 'java.exe');
+				if (fs.existsSync(javaExe)) {
+					process.env.JAVA_HOME = javaHome;
+					const javaBin = path.join(javaHome, 'bin');
+					process.env.PATH = `${javaBin}${path.delimiter}${process.env.PATH}`;
+
+					// Verify Java version
+					try {
+						const { stdout: version } = await execAsync(`"${javaExe}" -version`);
+						logService.info('Using Java from Machine JAVA_HOME:', javaHome);
+						logService.info('Java version:', version.split('\n')[0]);
+
+						await stateService.setItem('java.environmentSetup', true);
+						await stateService.setItem('java.source', 'machine');
+						return;
+					} catch (error) {
+						logService.warn('Java executable found but failed to get version:', error);
+					}
+				}
+			}
+		}
+
+		// Method 2: Check JAVA_HOME from User environment
+		if (isWindows) {
+			const getUserJavaHomeCmd = `powershell -Command "[Environment]::GetEnvironmentVariable('JAVA_HOME', 'User')"`;
+			const { stdout: userJavaHome } = await execAsync(getUserJavaHomeCmd);
+			const javaHome = userJavaHome.trim();
+
+			if (javaHome && fs.existsSync(javaHome)) {
+				const javaExe = path.join(javaHome, 'bin', 'java.exe');
+				if (fs.existsSync(javaExe)) {
+					process.env.JAVA_HOME = javaHome;
+					const javaBin = path.join(javaHome, 'bin');
+					process.env.PATH = `${javaBin}${path.delimiter}${process.env.PATH}`;
+
+					try {
+						const { stdout: version } = await execAsync(`"${javaExe}" -version`);
+						logService.info('Using Java from User JAVA_HOME:', javaHome);
+						logService.info('Java version:', version.split('\n')[0]);
+
+						await stateService.setItem('java.environmentSetup', true);
+						await stateService.setItem('java.source', 'user');
+						return;
+					} catch (error) {
+						logService.warn('Java executable found but failed to get version:', error);
+					}
+				}
+			}
+		}
+
+		// Method 3: Try to detect java in PATH
+		try {
+			const whereCmd = isWindows ? 'where java' : 'which java';
+			const { stdout: javaPath } = await execAsync(whereCmd);
+			const javaExe = javaPath.trim().split('\n')[0];
+
+			if (javaExe && fs.existsSync(javaExe)) {
+				const { stdout: version } = await execAsync(`"${javaExe}" -version`);
+				logService.info('Java found in system PATH:', javaExe);
+				logService.info('Java version:', version.split('\n')[0]);
+
+				// Try to determine JAVA_HOME from java.exe location
+				// Typically: C:\Program Files\Java\jdk-17\bin\java.exe -> C:\Program Files\Java\jdk-17
+				const javaBinDir = path.dirname(javaExe);
+				const javaHome = path.dirname(javaBinDir);
+
+				if (fs.existsSync(javaHome)) {
+					process.env.JAVA_HOME = javaHome;
+					logService.info('Derived JAVA_HOME from PATH:', javaHome);
+				}
+
+				await stateService.setItem('java.environmentSetup', true);
+				await stateService.setItem('java.source', 'path');
+				return;
+			}
+		} catch (error) {
+			logService.trace('Java not found in PATH:', error);
+		}
+
+		// Method 4: Check standard installation locations (last resort)
+		if (isWindows) {
+			const commonLocations = [
+				path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Eclipse Adoptium'),
+				path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Java'),
+				path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Java'),
+			];
+
+			for (const baseLocation of commonLocations) {
+				if (fs.existsSync(baseLocation)) {
+					try {
+						const jdkDirs = fs.readdirSync(baseLocation)
+							.filter(dir => dir.toLowerCase().includes('jdk'))
+							.sort()
+							.reverse(); // Get latest version first
+
+						for (const jdkDir of jdkDirs) {
+							const javaHome = path.join(baseLocation, jdkDir);
+							const javaExe = path.join(javaHome, 'bin', 'java.exe');
+
+							if (fs.existsSync(javaExe)) {
+								process.env.JAVA_HOME = javaHome;
+								const javaBin = path.join(javaHome, 'bin');
+								process.env.PATH = `${javaBin}${path.delimiter}${process.env.PATH}`;
+
+								try {
+									const { stdout: version } = await execAsync(`"${javaExe}" -version`);
+									logService.info('Found Java in standard location:', javaHome);
+									logService.info('Java version:', version.split('\n')[0]);
+
+									await stateService.setItem('java.environmentSetup', true);
+									await stateService.setItem('java.source', 'discovered');
+									return;
+								} catch (error) {
+									logService.trace('Failed to verify Java at:', javaHome);
+								}
+							}
+						}
+					} catch (error) {
+						logService.trace('Error scanning location:', baseLocation, error);
+					}
+				}
+			}
+		}
+
+		// No Java found
+		logService.warn('No Java installation detected. Java features may not work properly.');
+		logService.warn('Please install Java Development Kit 17 or later for full Salesforce development features.');
+		logService.warn('You can run the Siid installer again and select the "Download and install JDK" option.');
+
+		// Mark as setup attempted (to avoid repeated checks)
+		await stateService.setItem('java.environmentSetup', true);
+		await stateService.setItem('java.source', 'none');
+
+	} catch (error) {
+		logService.error('Error during Java environment setup:', error);
+		// Still mark as setup to avoid repeated failures
+		await stateService.setItem('java.environmentSetup', true);
+		await stateService.setItem('java.source', 'error');
+	}
+}
+
+/**
+ * Checks if Java is available and returns the version information
+ * @param logService - The log service for logging messages
+ * @returns Java version string or null if not available
+ */
+export async function getJavaVersion(logService: ILogService): Promise<string | null> {
+	try {
+		const javaCmd = isWindows ? 'java' : 'java';
+		const { stdout, stderr } = await execAsync(`${javaCmd} -version`);
+		const versionOutput = stderr || stdout;
+		const versionMatch = versionOutput.match(/version "(.+?)"/);
+
+		if (versionMatch) {
+			return versionMatch[1];
+		}
+
+		return versionOutput.split('\n')[0];
+	} catch (error) {
+		logService.trace('Failed to get Java version:', error);
+		return null;
+	}
+}

--- a/src/vs/code/electron-main/salesforceCliSetup.ts
+++ b/src/vs/code/electron-main/salesforceCliSetup.ts
@@ -1,0 +1,184 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as path from 'path';
+import * as fs from 'fs';
+import { ILogService } from '../../platform/log/common/log.js';
+import { IStateService } from '../../platform/state/node/state.js';
+import { isWindows } from '../../base/common/platform.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Sets up the Salesforce CLI environment.
+ * This function:
+ * 1. Checks if Salesforce CLI is already available in the system
+ * 2. Detects CLI installed by the Siid installer
+ * 3. Detects system-wide Salesforce CLI installations
+ * 4. Updates PATH for the current process if needed
+ * 5. Only runs once per installation (tracked via state service)
+ *
+ * Priority order:
+ * 1. 'sf' command in PATH (modern CLI)
+ * 2. 'sfdx' command in PATH (legacy CLI)
+ * 3. Standard installation locations (%LOCALAPPDATA%\sf, %LOCALAPPDATA%\sfdx)
+ * 4. Bundled CLI (if present in app resources)
+ *
+ * @param logService - The log service for logging messages
+ * @param stateService - The state service for tracking whether setup has been completed
+ */
+export async function setupSalesforceCliPath(logService: ILogService, stateService: IStateService): Promise<void> {
+	// Check if we've already set up the Salesforce CLI
+	const isSetup = stateService.getItem<boolean>('salesforce.cliPathSetup');
+	if (isSetup) {
+		logService.trace('Salesforce CLI path already configured, skipping setup');
+		return;
+	}
+
+	logService.info('Setting up Salesforce CLI...');
+
+	try {
+		// Method 1: Check if 'sf' command is available in PATH (modern CLI)
+		try {
+			const { stdout } = await execAsync('sf --version');
+			if (stdout) {
+				logService.info('Salesforce CLI (sf) found in system PATH');
+				logService.info('SF Version:', stdout.trim().split('\n')[0]);
+
+				stateService.setItem('salesforce.cliPathSetup', true);
+				stateService.setItem('salesforce.cliSource', 'path-sf');
+				return;
+			}
+		} catch (error) {
+			logService.trace('sf command not found in PATH');
+		}
+
+		// Method 2: Check if 'sfdx' command is available in PATH (legacy CLI)
+		try {
+			const { stdout } = await execAsync('sfdx --version');
+			if (stdout) {
+				logService.info('Salesforce CLI (sfdx) found in system PATH');
+				logService.info('SFDX Version:', stdout.trim().split('\n')[0]);
+
+				stateService.setItem('salesforce.cliPathSetup', true);
+				stateService.setItem('salesforce.cliSource', 'path-sfdx');
+				return;
+			}
+		} catch (error) {
+			logService.trace('sfdx command not found in PATH');
+		}
+
+		// Method 3: Check standard installation locations
+		if (isWindows) {
+			const localAppData = process.env.LOCALAPPDATA || path.join(process.env.USERPROFILE || '', 'AppData', 'Local');
+
+			// Check for modern SF CLI
+			const sfCliPath = path.join(localAppData, 'sf', 'bin');
+			const sfExe = path.join(sfCliPath, 'sf.exe');
+
+			if (fs.existsSync(sfExe)) {
+				process.env.PATH = `${sfCliPath}${path.delimiter}${process.env.PATH}`;
+
+				try {
+					const { stdout } = await execAsync(`"${sfExe}" --version`);
+					logService.info('Salesforce CLI (sf) found at:', sfCliPath);
+					logService.info('SF Version:', stdout.trim().split('\n')[0]);
+
+					stateService.setItem('salesforce.cliPathSetup', true);
+					stateService.setItem('salesforce.cliSource', 'local-sf');
+					return;
+				} catch (error) {
+					logService.warn('Found sf.exe but failed to get version:', error);
+				}
+			}
+
+			// Check for legacy SFDX CLI
+			const sfdxCliPath = path.join(localAppData, 'sfdx', 'bin');
+			const sfdxExe = path.join(sfdxCliPath, 'sfdx.exe');
+
+			if (fs.existsSync(sfdxExe)) {
+				process.env.PATH = `${sfdxCliPath}${path.delimiter}${process.env.PATH}`;
+
+				try {
+					const { stdout } = await execAsync(`"${sfdxExe}" --version`);
+					logService.info('Salesforce CLI (sfdx) found at:', sfdxCliPath);
+					logService.info('SFDX Version:', stdout.trim().split('\n')[0]);
+
+					stateService.setItem('salesforce.cliPathSetup', true);
+					stateService.setItem('salesforce.cliSource', 'local-sfdx');
+					return;
+				} catch (error) {
+					logService.warn('Found sfdx.exe but failed to get version:', error);
+				}
+			}
+		}
+
+		// Method 4: Check bundled CLI (fallback for legacy bundled approach)
+		const appResourcesPath = process.resourcesPath;
+		const bundledCliPath = path.join(appResourcesPath, 'app', 'node_modules', '.bin');
+
+		if (fs.existsSync(bundledCliPath)) {
+			const sfExe = path.join(bundledCliPath, isWindows ? 'sf.cmd' : 'sf');
+			const sfdxExe = path.join(bundledCliPath, isWindows ? 'sfdx.cmd' : 'sfdx');
+
+			if (fs.existsSync(sfExe) || fs.existsSync(sfdxExe)) {
+				process.env.PATH = `${bundledCliPath}${path.delimiter}${process.env.PATH}`;
+
+				try {
+					const testExe = fs.existsSync(sfExe) ? sfExe : sfdxExe;
+					const { stdout } = await execAsync(`"${testExe}" --version`);
+					logService.info('Using bundled Salesforce CLI from:', bundledCliPath);
+					logService.info('CLI Version:', stdout.trim().split('\n')[0]);
+
+					stateService.setItem('salesforce.cliPathSetup', true);
+					stateService.setItem('salesforce.cliSource', 'bundled');
+					return;
+				} catch (error) {
+					logService.warn('Found bundled CLI but failed to get version:', error);
+				}
+			}
+		}
+
+		// No Salesforce CLI found
+		logService.warn('No Salesforce CLI installation detected.');
+		logService.warn('Please install Salesforce CLI for full Salesforce development features.');
+		logService.warn('You can run the Siid installer again and select the "Download and install Salesforce CLI" option.');
+		logService.warn('Or download manually from: https://developer.salesforce.com/tools/salesforcecli');
+
+		// Mark as setup attempted (to avoid repeated checks)
+		stateService.setItem('salesforce.cliPathSetup', true);
+		stateService.setItem('salesforce.cliSource', 'none');
+
+	} catch (error) {
+		logService.error('Error during Salesforce CLI setup:', error);
+		// Still mark as setup to avoid repeated failures
+		stateService.setItem('salesforce.cliPathSetup', true);
+		stateService.setItem('salesforce.cliSource', 'error');
+	}
+}
+
+/**
+ * Checks if Salesforce CLI is available and returns the version information
+ * @param logService - The log service for logging messages
+ * @returns CLI version string or null if not available
+ */
+export async function getSalesforceCliVersion(logService: ILogService): Promise<string | null> {
+	try {
+		// Try 'sf' first (modern CLI)
+		try {
+			const { stdout } = await execAsync('sf --version');
+			return stdout.trim().split('\n')[0];
+		} catch {
+			// Try 'sfdx' (legacy CLI)
+			const { stdout } = await execAsync('sfdx --version');
+			return stdout.trim().split('\n')[0];
+		}
+	} catch (error) {
+		logService.trace('Failed to get Salesforce CLI version:', error);
+		return null;
+	}
+}

--- a/test-installer.ps1
+++ b/test-installer.ps1
@@ -1,0 +1,98 @@
+# Compiles ONLY the installer wizard (build/win32/code.iss) for fast UI testing.
+#
+# WHAT THIS IS FOR:
+#   Iterating on the "Required Dependencies" wizard page + dependency install
+#   flow without building the whole IDE. It stubs a minimal SourceDir so ISCC
+#   can package something, injects all required /d defs, and produces a runnable
+#   SIIDSetup.exe in a temp folder.
+#
+# WHAT THIS IS NOT:
+#   A shippable installer. The packaged payload is a FAKE Siid.exe + empty tools
+#   dir - the wizard runs, but there is no real IDE inside. To build the real,
+#   installable product use:  npx gulp vscode-win32-x64-user-setup
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File .\test-installer.ps1        # build only
+#   powershell -ExecutionPolicy Bypass -File .\test-installer.ps1 -Run   # build + launch
+# The script prints the SIIDSetup.exe path; step to the "Required Dependencies" page.
+# (Close any previously-run SIIDSetup.exe first, or the rebuild will be locked.)
+
+param(
+  # Launch the built installer automatically once compiled.
+  [switch]$Run
+)
+
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path .).Path
+$iscc = Join-Path $repo 'node_modules\innosetup\bin\ISCC.exe'
+if (-not (Test-Path $iscc)) { throw "ISCC not found at $iscc" }
+
+# --- Build a throwaway workspace: stub SourceDir + output dir ------------------
+$work    = Join-Path $env:TEMP 'siid-installer-test'
+$srcDir  = Join-Path $work 'src'          # stands in for the built VSCode-win32 app
+$outDir  = Join-Path $work 'out'
+$toolsDir = Join-Path $srcDir 'tools'
+Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $srcDir, $outDir, $toolsDir | Out-Null
+
+# [Files] does `Source: "*"` from SourceDir and `Source: "tools\*"`, and needs a
+# product.json to copy in. Give it the bare minimum so packaging succeeds.
+Set-Content -Path (Join-Path $srcDir 'Siid.exe') -Value 'stub' -Encoding ascii
+Set-Content -Path (Join-Path $toolsDir 'placeholder.txt') -Value 'stub' -Encoding ascii
+$productJson = Join-Path $outDir 'product.json'
+Copy-Item (Join-Path $repo 'product.json') $productJson -Force
+
+# --- All /d definitions the script references --------------------------------
+$defs = @{
+  NameLong               = 'Salesforce Intelligence Integrated Development'
+  NameShort              = 'Siid'
+  DirName                = 'Siid'
+  Version                = '1.115.0'
+  RawVersion             = '1.115.0'
+  NameVersion            = 'Salesforce Intelligence Integrated Development'
+  ExeBasename            = 'Siid'
+  RegValueName           = 'Siid'
+  ShellNameShort         = 'Siid'
+  AppMutex               = 'siid'
+  TunnelMutex            = 'siid-tunnel'
+  TunnelServiceMutex     = 'siid-tunnelservice'
+  TunnelApplicationName  = 'siid-tunnel'
+  ApplicationName        = 'siid'
+  Arch                   = 'x64'
+  AppId                  = '{{4DA0B567-9F3E-6FA4-D7E5-AC1B4E8G6D9F}'  # user AppId
+  IncompatibleTargetAppId = '{{2B8E9A45-7F1C-4D82-B5E3-8A9F2C6E4B7D}' # system AppId
+  AppUserId              = 'Conscendo.SalesforceIntelligenceIDE'
+  ArchitecturesAllowed   = 'x64'
+  ArchitecturesInstallIn64BitMode = 'x64'
+  SourceDir              = $srcDir
+  RepoDir                = $repo
+  OutputDir              = $outDir
+  InstallTarget          = 'user'
+  ProductJsonPath        = $productJson
+  Quality                = 'stable'
+}
+
+$defArgs = $defs.GetEnumerator() | ForEach-Object { "/d$($_.Key)=$($_.Value)" }
+$iss = Join-Path $repo 'build\win32\code.iss'
+
+Write-Host "Compiling installer (UI test build)..." -ForegroundColor Cyan
+& $iscc $iss @defArgs
+if ($LASTEXITCODE -ne 0) { throw "ISCC failed with exit code $LASTEXITCODE" }
+
+$exe = Join-Path $outDir 'SIIDSetup.exe'
+Write-Host ""
+Write-Host "OK. Installer built at:" -ForegroundColor Green
+Write-Host "  $exe"
+Write-Host ""
+Write-Host "To run it:" -ForegroundColor Yellow
+Write-Host "  Start-Process '$exe'"
+Write-Host "  (or re-run this script with -Run to launch it automatically)"
+Write-Host ""
+Write-Host "Click through to the 'Required Dependencies' page to see the UI." -ForegroundColor Yellow
+Write-Host "It is a real installer stub - use a throwaway install dir, or just Cancel after the page." -ForegroundColor Yellow
+
+if ($Run) {
+  Write-Host ""
+  Write-Host "Launching installer..." -ForegroundColor Cyan
+  Start-Process $exe
+}


### PR DESCRIPTION
Agent-edition port of #75 — installs the Salesforce CLI and Java JDK as part of IDE setup.

## What's included

- Inno Setup installer page that detects and installs SF CLI / JDK dependencies
- npm-based Salesforce CLI install with Windows PATH setup
- Java JDK detection, with a picker when multiple 17+ runtimes are present
- Dependency setup wired into `electron-main` app startup

| File | Change |
|---|---|
| `build/win32/code.iss` | +934 |
| `src/vs/code/electron-main/javaSetup.ts` | +214 |
| `src/vs/code/electron-main/salesforceCliSetup.ts` | +184 |
| `TESTING-INSTALLER.md` | +114 |
| `test-installer.ps1` | +98 |
| `src/vs/code/electron-main/app.ts` | +12 |

## Porting notes

Squashed into a single commit rather than replaying all 25 non-merge commits from `add-salesforce-cli`. The net diff of that branch touches no `package.json` or `package-lock.json` — the alpha version bumps cancel each other out — so replaying them would only have created conflicts against `main-agent`'s own version lineage for no benefit.

Excluded from the original branch: alpha version-bump bot commits, package-lock churn, and CI workflow experiments.

`.github/workflows/build-package-without-release.yml` is the 7th file in #75 but needed no change here — `main-agent` already has `runs-on: windows-2022`.

All six changed files were verified byte-identical to `add-salesforce-cli`.

## Testing

Not built or run — this is a source-identical port of the already-reviewed #75. Installer behaviour should be verified per `TESTING-INSTALLER.md` before merge.
